### PR TITLE
fix release ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           gh api repos/$GITHUB_REPOSITORY/releases/generate-notes \
             -f tag_name="${GITHUB_REF#refs/tags/}" \
             -f target_commitish=main \
-            -q .body > CHANGELOG.md
+            -q .body > .CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
@@ -34,7 +34,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: v1.12.3
-          args: release --release-notes=CHANGELOG.md
+          args: release --release-notes=.CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           GORELEASER_CURRENT_TAG: ${{steps.changelog.outputs.tag-name}}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 dist/
 
 .tidbcloud-cli.toml
+.CHANGELOG.md

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -117,7 +117,8 @@ func shouldCheckAuth(cmd *cobra.Command) bool {
 	cmdPrefixShouldSkip := []string{
 		fmt.Sprintf("%s %s", cliName, "config"),
 		fmt.Sprintf("%s %s", cliName, "help"),
-		fmt.Sprintf("%s %s", cliName, "completion")}
+		fmt.Sprintf("%s %s", cliName, "completion"),
+		fmt.Sprintf("%s %s", cliName, "version")}
 	for _, p := range cmdPrefixShouldSkip {
 		if strings.HasPrefix(cmd.CommandPath(), p) {
 			return false


### PR DESCRIPTION
- add .CHANGELOG.md to gitignore to prevent go-releaser error.
- skip auth validation for version command.