### PR TITLE
remove copy comand to /usr/local/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,24 @@ The `ticloud` command line tool brings deploy cluster requests, and other TiDB C
 
 - amd64
 ```
-curl -L https://github.com/tidbcloud/tidbcloud-cli/releases/download/v0.1.0-rc1/ticloud_0.1.0-rc1_macos_x86_64.tar.gz | tar -xz && cp -i ticloud /usr/local/bin/
+curl -L https://github.com/tidbcloud/tidbcloud-cli/releases/download/v0.1.0-rc1/ticloud_0.1.0-rc1_macos_x86_64.tar.gz | tar -xz 
 ```
 
 - arm64
 ```
-curl -L https://github.com/tidbcloud/tidbcloud-cli/releases/download/v0.1.0-rc1/ticloud_0.1.0-rc1_macos_arm64.tar.gz | tar -xz && cp -i ticloud /usr/local/bin/
+curl -L https://github.com/tidbcloud/tidbcloud-cli/releases/download/v0.1.0-rc1/ticloud_0.1.0-rc1_macos_arm64.tar.gz | tar -xz
 ```
 
 #### Linux
 
 - amd64
 ```
-curl -L https://github.com/tidbcloud/tidbcloud-cli/releases/download/v0.1.0-rc1/ticloud_0.1.0-rc1_linux_x86_64.tar.gz | tar -xz && cp -i ticloud /usr/local/bin/
+curl -L https://github.com/tidbcloud/tidbcloud-cli/releases/download/v0.1.0-rc1/ticloud_0.1.0-rc1_linux_x86_64.tar.gz | tar -xz
 ```
 
 - arm64
 ```
-curl -L https://github.com/tidbcloud/tidbcloud-cli/releases/download/v0.1.0-rc1/ticloud_0.1.0-rc1_linux_arm64.tar.gz | tar -xz && cp -i ticloud /usr/local/bin/
+curl -L https://github.com/tidbcloud/tidbcloud-cli/releases/download/v0.1.0-rc1/ticloud_0.1.0-rc1_linux_arm64.tar.gz | tar -xz
 ```
 
 #### Manually


### PR DESCRIPTION
Copying a regular file to /usr/local/bin in macOS is prohibited.
Copying a regular file to /usr/local/bin in macOS require the root privilege.
It's better to let the user choose his way.