### PR TITLE
Use select model rather than input model with projectIDs

### DIFF
--- a/internal/cli/cluster/create_test.go
+++ b/internal/cli/cluster/create_test.go
@@ -59,7 +59,7 @@ func (suite *CreateClusterSuite) TestCreateClusterArgs() {
 	projectID := "12345"
 	clusterID := "12345"
 	clusterName := "test"
-	clusterType := "DEVELOPER"
+	clusterType := "SERVERLESS"
 	cloudProvider := "AWS"
 	region := "us-west-1"
 	rootPassword := "123456"
@@ -79,7 +79,7 @@ func (suite *CreateClusterSuite) TestCreateClusterArgs() {
 					}
 				]
 			}
-			}`, clusterName, clusterType, cloudProvider, region, rootPassword)))
+			}`, clusterName, "DEVELOPER", cloudProvider, region, rootPassword)))
 	assert.Nil(err)
 
 	body := &cluster.GetClusterOKBody{}

--- a/internal/cli/cluster/delete_test.go
+++ b/internal/cli/cluster/delete_test.go
@@ -74,12 +74,12 @@ func (suite *DeleteClusterSuite) TestDeleteClusterArgs() {
 		{
 			name:         "delete cluster success",
 			args:         []string{"--project-id", projectID, "--cluster-id", clusterID},
-			stdoutString: "cluster deleted",
+			stdoutString: "cluster deleted\n",
 		},
 		{
 			name:         "delete cluster with output flag",
 			args:         []string{"-p", projectID, "-c", clusterID},
-			stdoutString: "cluster deleted",
+			stdoutString: "cluster deleted\n",
 		},
 		{
 			name: "delete cluster without required project id",

--- a/internal/cli/cluster/describe.go
+++ b/internal/cli/cluster/describe.go
@@ -19,12 +19,15 @@ import (
 	"fmt"
 
 	"tidbcloud-cli/internal"
+	"tidbcloud-cli/internal/cli/project"
 	"tidbcloud-cli/internal/config"
 	"tidbcloud-cli/internal/flag"
 	"tidbcloud-cli/internal/ui"
 
 	clusterApi "github.com/c4pt0r/go-tidbcloud-sdk-v1/client/cluster"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/emirpasic/gods/sets/hashset"
+	"github.com/fatih/color"
 	"github.com/juju/errors"
 	"github.com/spf13/cobra"
 )
@@ -65,17 +68,54 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 				}
 
 				// interactive mode
-				p := tea.NewProgram(initialClusterIdentifies())
-				inputModel, err := p.StartReturningModel()
+				_, projectItems, err := project.RetrieveProjects(h.QueryPageSize, h.Client())
+				if err != nil {
+					return err
+				}
+				set := hashset.New()
+				for _, item := range projectItems {
+					set.Add(item.ID)
+				}
+				model, err := ui.InitialSelectModel(set.Values(), "Choose the project ID:")
+				if err != nil {
+					return err
+				}
+				p := tea.NewProgram(model)
+				projectModel, err := p.StartReturningModel()
 				if err != nil {
 					return errors.Trace(err)
 				}
-				if inputModel.(ui.TextInputModel).Interrupted {
+				if m, _ := projectModel.(ui.SelectModel); m.Interrupted {
 					return nil
 				}
+				projectID = projectModel.(ui.SelectModel).Choices[projectModel.(ui.SelectModel).Selected].(string)
 
-				projectID = inputModel.(ui.TextInputModel).Inputs[projectIDIdx].Value()
-				clusterID = inputModel.(ui.TextInputModel).Inputs[clusterIDIdx].Value()
+				_, clusterItems, err := retrieveClusters(projectID, h.QueryPageSize, h.Client())
+				if err != nil {
+					return err
+				}
+				set = hashset.New()
+				for _, item := range clusterItems {
+					set.Add(*(item.ID))
+				}
+				clusters := set.Values()
+				if len(clusters) == 0 {
+					fmt.Fprintln(h.IOStreams.Out, color.YellowString("No available clusters found"))
+					return nil
+				}
+				model, err = ui.InitialSelectModel(clusters, "Choose the cluster ID:")
+				if err != nil {
+					return err
+				}
+				p = tea.NewProgram(model)
+				clusterModel, err := p.StartReturningModel()
+				if err != nil {
+					return errors.Trace(err)
+				}
+				if m, _ := clusterModel.(ui.SelectModel); m.Interrupted {
+					return nil
+				}
+				clusterID = clusterModel.(ui.SelectModel).Choices[clusterModel.(ui.SelectModel).Selected].(string)
 			} else {
 				// non-interactive mode, get values from flags
 				pID, err := cmd.Flags().GetString(flag.ProjectID)

--- a/internal/cli/cluster/list.go
+++ b/internal/cli/cluster/list.go
@@ -44,24 +44,11 @@ func ListCmd(h *internal.Helper) *cobra.Command {
   $ %[1]s cluster list <projectID> -o json`, config.CliName),
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			d := h.Client()
 			pID := args[0]
 
-			params := clusterApi.NewListClustersOfProjectParams().WithProjectID(pID)
-			var total int64 = math.MaxInt64
-			var page int64 = 1
-			var pageSize = h.QueryPageSize
-			var items []*clusterApi.ListClustersOfProjectOKBodyItemsItems0
-			// loop to get all clusters
-			for (page-1)*pageSize < total {
-				clusters, err := d.ListClustersOfProject(params.WithPage(&page).WithPageSize(&pageSize))
-				if err != nil {
-					return errors.Trace(err)
-				}
-
-				total = *clusters.Payload.Total
-				page += 1
-				items = append(items, clusters.Payload.Items...)
+			total, items, err := retrieveClusters(pID, h.QueryPageSize, h.Client())
+			if err != nil {
+				return err
 			}
 
 			format, err := cmd.Flags().GetString(flag.Output)
@@ -119,4 +106,23 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 
 	listCmd.Flags().StringP(flag.Output, flag.OutputShort, output.HumanFormat, "Output format. One of: human, json, default: human")
 	return listCmd
+}
+
+func retrieveClusters(pID string, pageSize int64, d util.CloudClient) (int64, []*clusterApi.ListClustersOfProjectOKBodyItemsItems0, error) {
+	params := clusterApi.NewListClustersOfProjectParams().WithProjectID(pID)
+	var total int64 = math.MaxInt64
+	var page int64 = 1
+	var items []*clusterApi.ListClustersOfProjectOKBodyItemsItems0
+	// loop to get all clusters
+	for (page-1)*pageSize < total {
+		clusters, err := d.ListClustersOfProject(params.WithPage(&page).WithPageSize(&pageSize))
+		if err != nil {
+			return 0, nil, errors.Trace(err)
+		}
+
+		total = *clusters.Payload.Total
+		page += 1
+		items = append(items, clusters.Payload.Items...)
+	}
+	return total, items, nil
 }

--- a/internal/cli/project/list.go
+++ b/internal/cli/project/list.go
@@ -23,6 +23,7 @@ import (
 	"tidbcloud-cli/internal/config"
 	"tidbcloud-cli/internal/flag"
 	"tidbcloud-cli/internal/output"
+	"tidbcloud-cli/internal/util"
 
 	projectApi "github.com/c4pt0r/go-tidbcloud-sdk-v1/client/project"
 	"github.com/charmbracelet/bubbles/table"
@@ -41,22 +42,9 @@ func ListCmd(h *internal.Helper) *cobra.Command {
   List the projects with json format:
   $ %[1]s project list -o json`, config.CliName),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			d := h.Client()
-			params := projectApi.NewListProjectsParams()
-
-			var total int64 = math.MaxInt64
-			var page int64 = 1
-			var pageSize = h.QueryPageSize
-			var items []*projectApi.ListProjectsOKBodyItemsItems0
-			for (page-1)*pageSize < total {
-				projects, err := d.ListProjects(params.WithPage(&page).WithPageSize(&pageSize))
-				if err != nil {
-					return errors.Trace(err)
-				}
-
-				total = *projects.Payload.Total
-				page += 1
-				items = append(items, projects.Payload.Items...)
+			total, items, err := RetrieveProjects(h.QueryPageSize, h.Client())
+			if err != nil {
+				return err
 			}
 
 			format, err := cmd.Flags().GetString(flag.Output)
@@ -107,4 +95,23 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 
 	listCmd.Flags().StringP(flag.Output, flag.OutputShort, output.HumanFormat, "Output format. One of: json|human, default: human")
 	return listCmd
+}
+
+func RetrieveProjects(size int64, d util.CloudClient) (int64, []*projectApi.ListProjectsOKBodyItemsItems0, error) {
+	params := projectApi.NewListProjectsParams()
+	var total int64 = math.MaxInt64
+	var page int64 = 1
+	var pageSize = size
+	var items []*projectApi.ListProjectsOKBodyItemsItems0
+	for (page-1)*pageSize < total {
+		projects, err := d.ListProjects(params.WithPage(&page).WithPageSize(&pageSize))
+		if err != nil {
+			return 0, nil, errors.Trace(err)
+		}
+
+		total = *projects.Payload.Total
+		page += 1
+		items = append(items, projects.Payload.Items...)
+	}
+	return total, items, nil
 }

--- a/internal/ui/select_model.go
+++ b/internal/ui/select_model.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/fatih/color"
+	"github.com/juju/errors"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -30,8 +31,12 @@ type SelectModel struct {
 	Interrupted bool
 }
 
-func InitialSelectModel(choices []interface{}, hint string) SelectModel {
-	return SelectModel{
+func InitialSelectModel(choices []interface{}, hint string) (*SelectModel, error) {
+	if len(choices) == 0 {
+		return nil, errors.New("There are no available choices")
+	}
+
+	return &SelectModel{
 		// Our to-do list is a grocery list
 		Choices: choices,
 
@@ -41,7 +46,7 @@ func InitialSelectModel(choices []interface{}, hint string) SelectModel {
 		Selected:    -1,
 		Interrupted: false,
 		Hint:        hint,
-	}
+	}, nil
 }
 
 func (m SelectModel) Init() tea.Cmd {


### PR DESCRIPTION
- Use the select model rather than the input model with project IDs.
- Use "SERVERLESS" rather than "DEVELOPER" when creating clusters.