### PR TITLE
Text polishing

### DIFF
--- a/internal/cli/cluster/cluster.go
+++ b/internal/cli/cluster/cluster.go
@@ -29,7 +29,7 @@ var (
 func ClusterCmd(h *internal.Helper) *cobra.Command {
 	var clusterCmd = &cobra.Command{
 		Use:   "cluster",
-		Short: "Manage clusters for your project.",
+		Short: "Manage clusters for your project",
 	}
 
 	clusterCmd.AddCommand(CreateCmd(h))

--- a/internal/cli/cluster/create.go
+++ b/internal/cli/cluster/create.go
@@ -53,7 +53,7 @@ type CreateServerlessOpts struct {
 func CreateCmd(h *internal.Helper) *cobra.Command {
 	var createCmd = &cobra.Command{
 		Use:   "create",
-		Short: "Create one cluster in the specified project.",
+		Short: "Create one cluster in the specified project",
 		Example: fmt.Sprintf(`  Create a cluster in interactive mode:
   $ %[1]s cluster create
 

--- a/internal/cli/cluster/delete.go
+++ b/internal/cli/cluster/delete.go
@@ -35,7 +35,7 @@ import (
 func DeleteCmd(h *internal.Helper) *cobra.Command {
 	var deleteCmd = &cobra.Command{
 		Use:   "delete",
-		Short: "Delete a cluster from your project.",
+		Short: "Delete a cluster from your project",
 		Example: fmt.Sprintf(`  Delete a cluster in interactive mode:
   $ %[1]s cluster delete
 

--- a/internal/cli/cluster/describe.go
+++ b/internal/cli/cluster/describe.go
@@ -35,7 +35,7 @@ import (
 func DescribeCmd(h *internal.Helper) *cobra.Command {
 	var describeCmd = &cobra.Command{
 		Use:     "describe",
-		Short:   "Describe a cluster.",
+		Short:   "Describe a cluster",
 		Aliases: []string{"get"},
 		Example: fmt.Sprintf(`  Get the cluster info in interactive mode:
   $ %[1]s cluster describe

--- a/internal/cli/cluster/list.go
+++ b/internal/cli/cluster/list.go
@@ -35,7 +35,7 @@ import (
 func ListCmd(h *internal.Helper) *cobra.Command {
 	var listCmd = &cobra.Command{
 		Use:   "list <projectID>",
-		Short: "List all clusters in a project.",
+		Short: "List all clusters in a project",
 		Args:  util.RequiredArgs("projectID"),
 		Example: fmt.Sprintf(`  List the clusters in the project:
   $ %[1]s cluster list <projectID> 

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -23,10 +23,10 @@ import (
 func ConfigCmd(h *internal.Helper) *cobra.Command {
 	var configCmd = &cobra.Command{
 		Use:   "config",
-		Short: "Configure and manage your user profiles.",
+		Short: "Configure and manage your user profiles",
 	}
 
-	configCmd.AddCommand(InitCmd(h))
+	configCmd.AddCommand(CreateCmd(h))
 	configCmd.AddCommand(ListCmd(h))
 	configCmd.AddCommand(DeleteCmd(h))
 	configCmd.AddCommand(SetCmd(h))

--- a/internal/cli/config/create.go
+++ b/internal/cli/config/create.go
@@ -39,23 +39,23 @@ var (
 	cursorStyle  = focusedStyle.Copy()
 )
 
-type initConfigField int
+type createConfigField int
 
 const (
-	profileNameIdx initConfigField = iota
+	profileNameIdx createConfigField = iota
 	publicKeyIdx
 	privateKeyIdx
 )
 
-func InitCmd(h *internal.Helper) *cobra.Command {
-	var initCmd = &cobra.Command{
-		Use:   "init",
+func CreateCmd(h *internal.Helper) *cobra.Command {
+	var createCmd = &cobra.Command{
+		Use:   "create",
 		Short: "Configure a profile to store access settings",
 		Example: fmt.Sprintf(`  To configure the tool to work with TiDB Cloud in interactive mode:
-  $ %[1]s config init
+  $ %[1]s config create
 
   To configure the tool to work with TiDB Cloud in non-interactive mode::
-  $ %[1]s config init --profile-name <profile-name> --public-key <public-key> --private-key <private-key>`, config.CliName),
+  $ %[1]s config create --profile-name <profile-name> --public-key <public-key> --private-key <private-key>`, config.CliName),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// mark required flags in non-interactive mode
 			if cmd.Flags().NFlag() != 0 {
@@ -142,10 +142,10 @@ func InitCmd(h *internal.Helper) *cobra.Command {
 		},
 	}
 
-	initCmd.Flags().String(flag.ProfileName, "", "the name of the profile to be created")
-	initCmd.Flags().String(flag.PublicKey, "", "the public key of the TiDB Cloud API")
-	initCmd.Flags().String(flag.PrivateKey, "", "the private key of the TiDB Cloud API")
-	return initCmd
+	createCmd.Flags().String(flag.ProfileName, "", "the name of the profile to be created")
+	createCmd.Flags().String(flag.PublicKey, "", "the public key of the TiDB Cloud API")
+	createCmd.Flags().String(flag.PrivateKey, "", "the private key of the TiDB Cloud API")
+	return createCmd
 }
 
 func initialDeletionInputModel() ui.TextInputModel {
@@ -158,7 +158,7 @@ func initialDeletionInputModel() ui.TextInputModel {
 		t = textinput.New()
 		t.CursorStyle = cursorStyle
 		t.CharLimit = 64
-		f := initConfigField(i)
+		f := createConfigField(i)
 
 		switch f {
 		case profileNameIdx:

--- a/internal/cli/config/create_test.go
+++ b/internal/cli/config/create_test.go
@@ -29,12 +29,12 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type InitConfigSuite struct {
+type CreateConfigSuite struct {
 	suite.Suite
 	h *internal.Helper
 }
 
-func (suite *InitConfigSuite) SetupTest() {
+func (suite *CreateConfigSuite) SetupTest() {
 	if err := os.Setenv("NO_COLOR", "true"); err != nil {
 		suite.T().Error(err)
 	}
@@ -49,14 +49,14 @@ func (suite *InitConfigSuite) SetupTest() {
 	}
 }
 
-func (suite *InitConfigSuite) TearDownTest() {
+func (suite *CreateConfigSuite) TearDownTest() {
 	err := util.RemoveFile(".tidbcloud-cli.toml")
 	if err != nil {
 		suite.T().Error(err)
 	}
 }
 
-func (suite *InitConfigSuite) TestInitConfigArgs() {
+func (suite *CreateConfigSuite) TestCreateConfigArgs() {
 	assert := require.New(suite.T())
 	profile := "test"
 	publicKey := "SDIWODIJQNDKJQW"
@@ -70,12 +70,12 @@ func (suite *InitConfigSuite) TestInitConfigArgs() {
 		stderrString string
 	}{
 		{
-			name:         "init config",
+			name:         "create config",
 			args:         []string{"--profile-name", profile, "--public-key", publicKey, "--private-key", privateKey},
 			stdoutString: "Check the https://docs.pingcap.com/tidbcloud/api/v1beta#section/Authentication/API-Key-Management for more information about how to create API keys.\nCurrent profile has been changed to test\n",
 		},
 		{
-			name: "init config without required private key",
+			name: "create config without required private key",
 			args: []string{"--profile-name", profile, "--public-key", publicKey},
 			err:  fmt.Errorf("required flag(s) \"private-key\" not set"),
 		},
@@ -86,7 +86,7 @@ func (suite *InitConfigSuite) TestInitConfigArgs() {
 			err := viper.ReadInConfig()
 			assert.Nil(err)
 
-			cmd := InitCmd(suite.h)
+			cmd := CreateCmd(suite.h)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)
@@ -99,7 +99,7 @@ func (suite *InitConfigSuite) TestInitConfigArgs() {
 	}
 }
 
-func (suite *InitConfigSuite) TestInitConfigWithExistedProfile() {
+func (suite *CreateConfigSuite) TestCreateConfigWithExistedProfile() {
 	assert := require.New(suite.T())
 	profile := "test"
 	publicKey := "SDIWODIJQNDKJQW"
@@ -121,7 +121,7 @@ func (suite *InitConfigSuite) TestInitConfigWithExistedProfile() {
 		stderrString string
 	}{
 		{
-			name:         "init config with existed profile",
+			name:         "create config with existed profile",
 			args:         []string{"--profile-name", profile, "--public-key", publicKey, "--private-key", privateKey},
 			err:          fmt.Errorf("profile test already exists, use `config set` to modify"),
 			stdoutString: "Check the https://docs.pingcap.com/tidbcloud/api/v1beta#section/Authentication/API-Key-Management for more information about how to create API keys.\n",
@@ -133,7 +133,7 @@ func (suite *InitConfigSuite) TestInitConfigWithExistedProfile() {
 			err := viper.ReadInConfig()
 			assert.Nil(err)
 
-			cmd := InitCmd(suite.h)
+			cmd := CreateCmd(suite.h)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)
@@ -146,6 +146,6 @@ func (suite *InitConfigSuite) TestInitConfigWithExistedProfile() {
 	}
 }
 
-func TestInitConfigSuite(t *testing.T) {
-	suite.Run(t, new(InitConfigSuite))
+func TestCreateConfigSuite(t *testing.T) {
+	suite.Run(t, new(CreateConfigSuite))
 }

--- a/internal/cli/config/describe.go
+++ b/internal/cli/config/describe.go
@@ -31,7 +31,7 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 	describeCmd := &cobra.Command{
 		Use:     "describe <profileName>",
 		Aliases: []string{"get"},
-		Short:   "Return a specific profile.",
+		Short:   "Return a specific profile",
 		Example: fmt.Sprintf(`  Return the profile configuration:
   $ %[1]s config describe <profileName>`, config.CliName),
 		Args: util.RequiredArgs("profileName"),

--- a/internal/cli/config/edit.go
+++ b/internal/cli/config/edit.go
@@ -31,7 +31,7 @@ const defaultEditor = "vi"
 func EditCmd() *cobra.Command {
 	var listCmd = &cobra.Command{
 		Use:   "edit",
-		Short: "Opens the config file with the default text editor.",
+		Short: "Open the config file with the default text editor",
 		Example: fmt.Sprintf(`  To open the config
   $ %[1]s config edit`, config.CliName),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/config/list.go
+++ b/internal/cli/config/list.go
@@ -30,7 +30,7 @@ import (
 func ListCmd(h *internal.Helper) *cobra.Command {
 	var listCmd = &cobra.Command{
 		Use:     "list",
-		Short:   "list all profiles",
+		Short:   "List all profiles",
 		Aliases: []string{"ls"},
 		Example: fmt.Sprintf(`  Return a list of available profiles by name:
   $ %[1]s config list`, config.CliName),
@@ -44,7 +44,7 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 			fmt.Fprintf(h.IOStreams.Out, "Profile Name\n")
 			for _, key := range profiles {
 				if key == curP {
-					fmt.Fprintf(h.IOStreams.Out, color.GreenString(key+"\t*\n"))
+					fmt.Fprintf(h.IOStreams.Out, color.GreenString(key+"\t(active)\n"))
 				} else {
 					fmt.Fprintf(h.IOStreams.Out, color.GreenString(key+"\n"))
 				}

--- a/internal/cli/config/list_test.go
+++ b/internal/cli/config/list_test.go
@@ -81,7 +81,7 @@ func (suite *ListConfigSuite) TestListConfigArgs() {
 		{
 			name:         "list config",
 			args:         []string{},
-			stdoutString: "Profile Name\ntest\t*\ntest1\n",
+			stdoutString: "Profile Name\ntest\t(active)\ntest1\n",
 		},
 	}
 

--- a/internal/cli/config/set.go
+++ b/internal/cli/config/set.go
@@ -31,7 +31,7 @@ import (
 func SetCmd(h *internal.Helper) *cobra.Command {
 	var setCmd = &cobra.Command{
 		Use:   "set <propertyName> <value>",
-		Short: "Configure specific properties of the active profile.",
+		Short: "Configure specific properties of the active profile",
 		Long: fmt.Sprintf(`Configure specific properties of the active profile.
 Available properties : %v.
 
@@ -51,7 +51,7 @@ If not, the config in the active profile will be set`, prop.ProfileProperties())
 			if util.StringInSlice(prop.ProfileProperties(), propertyName) {
 				curP := h.Config.ActiveProfile
 				if curP == "" {
-					return fmt.Errorf("no profile is configured, please use `config init` to create a profile")
+					return fmt.Errorf("no profile is configured, please use `config create` to create a profile")
 				}
 				viper.Set(fmt.Sprintf("%s.%s", curP, propertyName), value)
 				res = fmt.Sprintf("Set profile `%s` property `%s` to value `%s` successfully", curP, propertyName, value)

--- a/internal/cli/config/set_test.go
+++ b/internal/cli/config/set_test.go
@@ -143,7 +143,7 @@ func (suite *SetConfigSuite) TestSetConfigWhenNoActiveProfile() {
 		{
 			name: "set config",
 			args: []string{"private_key", "value"},
-			err:  fmt.Errorf("no profile is configured, please use `config init` to create a profile"),
+			err:  fmt.Errorf("no profile is configured, please use `config create` to create a profile"),
 		},
 	}
 

--- a/internal/cli/config/use.go
+++ b/internal/cli/config/use.go
@@ -31,7 +31,7 @@ import (
 func UseCmd(h *internal.Helper) *cobra.Command {
 	var listCmd = &cobra.Command{
 		Use:   "use <profileName>",
-		Short: "Use the specified profile as the active profile.",
+		Short: "Use the specified profile as the active profile",
 		Example: fmt.Sprintf(`  Use the "test" profile as the active profile:
   $ %[1]s config use test`, config.CliName),
 		Args: util.RequiredArgs("profileName"),

--- a/internal/cli/project/list.go
+++ b/internal/cli/project/list.go
@@ -34,7 +34,7 @@ import (
 func ListCmd(h *internal.Helper) *cobra.Command {
 	var listCmd = &cobra.Command{
 		Use:     "list",
-		Short:   "List all accessible projects.",
+		Short:   "List all accessible projects",
 		Aliases: []string{"ls"},
 		Example: fmt.Sprintf(`  List the projects:
   $ %[1]s project list

--- a/internal/cli/project/project.go
+++ b/internal/cli/project/project.go
@@ -23,7 +23,7 @@ import (
 func ProjectCmd(h *internal.Helper) *cobra.Command {
 	var projectCmd = &cobra.Command{
 		Use:   "project",
-		Short: "Manage projects.",
+		Short: "Manage projects",
 	}
 
 	projectCmd.AddCommand(ListCmd(h))

--- a/internal/util/auth.go
+++ b/internal/util/auth.go
@@ -24,7 +24,7 @@ import (
 
 func CheckAuth(profile string) error {
 	if profile == "" {
-		return fmt.Errorf("no active profile for auth, please use `config init` to create one")
+		return fmt.Errorf("no active profile for auth, please use `config create` to create one")
 	}
 
 	publicKey := viper.Get(fmt.Sprintf("%s.%s", profile, prop.PublicKey))


### PR DESCRIPTION
- remove period in short description.
- rename `config init` to `config create`