### PR TITLE
Use foreground color rather than background color

### DIFF
--- a/internal/cli/cluster/list.go
+++ b/internal/cli/cluster/list.go
@@ -69,7 +69,7 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 				}
 			} else if format == output.HumanFormat {
 				// for human format, we print the table with brief information.
-				color.New(color.BgYellow).Fprintf(h.IOStreams.Out, "  For detailed information, please output with json format.")
+				color.New(color.FgYellow).Fprintf(h.IOStreams.Out, "  For detailed information, please output with json format.")
 				columns := []table.Column{
 					{Title: "ID", Width: 20},
 					{Title: "Name", Width: 20},

--- a/internal/cli/config/create.go
+++ b/internal/cli/config/create.go
@@ -136,7 +136,7 @@ func CreateCmd(h *internal.Helper) *cobra.Command {
 			}
 
 			fgGreen := color.New(color.FgGreen).SprintFunc()
-			hiGreen := color.New(color.FgHiGreen, color.BgWhite).SprintFunc()
+			hiGreen := color.New(color.FgHiCyan).SprintFunc()
 			fmt.Fprintf(h.IOStreams.Out, "%s %s\n", fgGreen("Current profile has been changed to"), hiGreen(profileName))
 			return nil
 		},

--- a/internal/cli/config/use.go
+++ b/internal/cli/config/use.go
@@ -63,7 +63,7 @@ func SetProfile(out io.Writer, profileName string) error {
 	}
 
 	fgGreen := color.New(color.FgGreen).SprintFunc()
-	hiGreen := color.New(color.FgHiGreen, color.BgWhite).SprintFunc()
+	hiGreen := color.New(color.FgHiCyan).SprintFunc()
 	fmt.Fprintf(out, "%s %s\n", fgGreen("Current profile has been changed to"), hiGreen(profileName))
 	return nil
 }


### PR DESCRIPTION
- If the user's terminal has its own background color, using background color may make the text not clear.