### PR TITLE
optimize update process

### DIFF
--- a/internal/cli/cluster/create.go
+++ b/internal/cli/cluster/create.go
@@ -286,7 +286,7 @@ func CreateAndWaitReady(h *internal.Helper, d cloud.TiDBCloudClient, projectID s
 	newClusterID := *createClusterResult.GetPayload().ID
 	ticker := time.NewTicker(1 * time.Second)
 
-	fmt.Fprintln(h.IOStreams.Out, "Waiting for cluster to be ready")
+	fmt.Fprintln(h.IOStreams.Out, "... Waiting for cluster to be ready")
 	for {
 		select {
 		case <-time.After(2 * time.Minute):

--- a/internal/cli/cluster/create_test.go
+++ b/internal/cli/cluster/create_test.go
@@ -110,12 +110,12 @@ func (suite *CreateClusterSuite) TestCreateClusterArgs() {
 		{
 			name:         "create cluster success",
 			args:         []string{"--project-id", projectID, "--cluster-name", clusterName, "--cluster-type", clusterType, "--cloud-provider", cloudProvider, "--region", region, "--root-password", rootPassword},
-			stdoutString: "Waiting for cluster to be ready...\nCluster 12345 is ready.",
+			stdoutString: "... Waiting for cluster to be ready\nCluster 12345 is ready.",
 		},
 		{
 			name:         "create cluster with shorthand flag",
 			args:         []string{"-p", projectID, "--cluster-name", clusterName, "--cluster-type", clusterType, "--cloud-provider", cloudProvider, "-r", region, "--root-password", rootPassword},
-			stdoutString: "Waiting for cluster to be ready...\nCluster 12345 is ready.",
+			stdoutString: "... Waiting for cluster to be ready\nCluster 12345 is ready.",
 		},
 		{
 			name: "without required project id",

--- a/internal/cli/update/update.go
+++ b/internal/cli/update/update.go
@@ -21,45 +21,124 @@ import (
 	"time"
 
 	"tidbcloud-cli/internal"
+	"tidbcloud-cli/internal/config"
+	"tidbcloud-cli/internal/service/github"
+	"tidbcloud-cli/internal/ui"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/fatih/color"
 	"github.com/juju/errors"
 	"github.com/spf13/cobra"
 )
 
-func UpdateCmd(h *internal.Helper) *cobra.Command {
+func UpdateCmd(h *internal.Helper, ver string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update the CLI to the latest version",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// 创建一个上下文并且设置超时时间
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-			defer cancel()
-
-			c1 := exec.CommandContext(ctx, "curl", "https://raw.githubusercontent.com/tidbcloud/tidbcloud-cli/main/install.sh")
-			if ctx.Err() == context.DeadlineExceeded {
-				return errors.New("timeout when download the install.sh script")
-			}
-			fmt.Fprintln(h.IOStreams.Out, color.GreenString("start to download the install.sh script"))
-			out, err := c1.Output()
+			// When update CLI, we don't need to check the version again after command executes.
+			newRelease, err := github.CheckForUpdate(config.Repo, ver, false)
 			if err != nil {
-				return errors.Annotate(err, "failed to download the install.sh script")
+				return err
+			}
+			if newRelease == nil {
+				fmt.Fprintln(h.IOStreams.Out, "The CLI is already up to date.")
+				return nil
 			}
 
-			fmt.Fprintln(h.IOStreams.Out, color.GreenString("done!"))
-			fmt.Fprintln(h.IOStreams.Out, color.GreenString("start to execute the install.sh script"))
-			result, err := exec.CommandContext(ctx, "/bin/sh", "-c", string(out)).Output() //nolint:gosec
-			if ctx.Err() == context.DeadlineExceeded {
-				return errors.New("timeout when execute the install.sh script")
+			if h.IOStreams.CanPrompt {
+				return CreateAndSpinnerWait(h, newRelease)
+			} else {
+				return CreateAndWaitReady(h, newRelease)
 			}
-			if err != nil {
-				return errors.Annotate(err, "execute the install.sh script")
-			}
-
-			fmt.Fprintln(h.IOStreams.Out, string(result))
-			return nil
 		},
 	}
 
 	return cmd
+}
+
+func CreateAndWaitReady(h *internal.Helper, newRelease *github.ReleaseInfo) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+	fmt.Fprintf(h.IOStreams.Out, "... Updating the CLI to version %s\n", newRelease.Version)
+	c1 := exec.CommandContext(ctx, "curl", "https://raw.githubusercontent.com/tidbcloud/tidbcloud-cli/main/install.sh")
+	if ctx.Err() == context.DeadlineExceeded {
+		return errors.New("timeout when download the install.sh script")
+	}
+
+	out, err := c1.Output()
+	if err != nil {
+		return errors.Annotate(err, "failed to download the install.sh script")
+	}
+
+	_, err = exec.CommandContext(ctx, "/bin/sh", "-c", string(out)).Output() //nolint:gosec
+	if ctx.Err() == context.DeadlineExceeded {
+		return errors.New("timeout when execute the install.sh script")
+	}
+	if err != nil {
+		return errors.Annotate(err, "execute the install.sh script")
+	}
+
+	fmt.Fprintln(h.IOStreams.Out, "Update successfully!")
+
+	return nil
+}
+
+func CreateAndSpinnerWait(h *internal.Helper, newRelease *github.ReleaseInfo) error {
+	task := func() tea.Msg {
+		res := make(chan error)
+
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			defer cancel()
+			c1 := exec.CommandContext(ctx, "curl", "https://raw.githubusercontent.com/tidbcloud/tidbcloud-cli/main/install.sh")
+			if ctx.Err() == context.DeadlineExceeded {
+				res <- errors.New("timeout when download the install.sh script")
+			}
+
+			out, err := c1.Output()
+			if err != nil {
+				res <- errors.Annotate(err, "failed to download the install.sh script")
+			}
+
+			_, err = exec.CommandContext(ctx, "/bin/sh", "-c", string(out)).Output() //nolint:gosec
+			if ctx.Err() == context.DeadlineExceeded {
+				res <- errors.New("timeout when execute the install.sh script")
+			}
+			if err != nil {
+				res <- errors.Annotate(err, "execute the install.sh script")
+			}
+
+			res <- nil
+		}()
+
+		ticker := time.NewTicker(1 * time.Second)
+		for {
+			select {
+			case <-ticker.C:
+				select {
+				case err := <-res:
+					if err != nil {
+						return err
+					} else {
+						return ui.Result("Update successfully!")
+					}
+				default:
+					// continue
+				}
+			}
+		}
+	}
+
+	p := tea.NewProgram(ui.InitialSpinnerModel(task, fmt.Sprintf("Updating the CLI to version %s", newRelease.Version)))
+	createModel, err := p.StartReturningModel()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if m, _ := createModel.(ui.SpinnerModel); m.Err != nil {
+		return m.Err
+	} else {
+		fmt.Fprintln(h.IOStreams.Out, color.GreenString(m.Output))
+	}
+	return nil
 }

--- a/internal/cli/update/update.go
+++ b/internal/cli/update/update.go
@@ -113,21 +113,20 @@ func CreateAndSpinnerWait(h *internal.Helper, newRelease *github.ReleaseInfo) er
 		}()
 
 		ticker := time.NewTicker(1 * time.Second)
-		for {
+		for range ticker.C {
 			select {
-			case <-ticker.C:
-				select {
-				case err := <-res:
-					if err != nil {
-						return err
-					} else {
-						return ui.Result("Update successfully!")
-					}
-				default:
-					// continue
+			case err := <-res:
+				if err != nil {
+					return err
+				} else {
+					return ui.Result("Update successfully!")
 				}
+			default:
+				// continue
 			}
 		}
+
+		return errors.New("update failed")
 	}
 
 	p := tea.NewProgram(ui.InitialSpinnerModel(task, fmt.Sprintf("Updating the CLI to version %s", newRelease.Version)))

--- a/internal/cli/version/version.go
+++ b/internal/cli/version/version.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"tidbcloud-cli/internal"
+	"tidbcloud-cli/internal/config"
 
 	"github.com/spf13/cobra"
 )
@@ -39,12 +40,12 @@ func VersionCmd(h *internal.Helper, ver, commit, buildDate string) *cobra.Comman
 // Format formats a version string with the given information.
 func Format(ver, commit, buildDate string) string {
 	if ver == "" && buildDate == "" && commit == "" {
-		return "pscale version (built from source)"
+		return fmt.Sprintf("%s version (built from source)", config.CliName)
 	}
 
 	ver = strings.TrimPrefix(ver, "v")
 
-	return fmt.Sprintf("pscale version %s (build date: %s commit: %s)\n%s\n", ver, buildDate, commit, changelogURL(ver))
+	return fmt.Sprintf("%s version %s (build date: %s commit: %s)\n%s\n", config.CliName, ver, buildDate, commit, changelogURL(ver))
 }
 
 func changelogURL(version string) string {

--- a/internal/ui/spinner_model.go
+++ b/internal/ui/spinner_model.go
@@ -78,7 +78,7 @@ func (m SpinnerModel) View() string {
 	if m.Output != "" {
 		return m.Output
 	}
-	str := color.New(color.FgYellow).Sprintf("%s %s...press q to quit \n", m.spinner.View(), m.Hint)
+	str := color.New(color.FgYellow).Sprintf("%s %s. press q to quit \n", m.spinner.View(), m.Hint)
 	if m.quitting {
 		return str + "\n"
 	}


### PR DESCRIPTION
- skip check version after executing 'update'.
- check the version forcibly before updating CLI.
- fix version return wrong the CLI name.