### PR TITLE
Use different name when under TiUP

### DIFF
--- a/internal/cli/update/update.go
+++ b/internal/cli/update/update.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"time"
 
@@ -26,7 +25,6 @@ import (
 	"tidbcloud-cli/internal/config"
 	"tidbcloud-cli/internal/service/github"
 	"tidbcloud-cli/internal/ui"
-	"tidbcloud-cli/internal/util"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/fatih/color"
@@ -39,12 +37,8 @@ func UpdateCmd(h *internal.Helper, ver string) *cobra.Command {
 		Use:   "update",
 		Short: "Update the CLI to the latest version",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var binpath string
-			if exepath, err := os.Executable(); err == nil {
-				binpath = exepath
-			}
 			// If is managed by TiUP, we should disable the update command since binpath is different.
-			if util.IsUnderTiUP(binpath) {
+			if h.IsUnderTiUP {
 				return errors.New("the CLI is managed by TiUP, please update it by `tiup update cloud`")
 			}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,14 +25,25 @@ import (
 )
 
 const (
-	CliName    = "ticloud"
-	HomePath   = ".ticloud"
-	DevVersion = "dev"
-	Repo       = "tidbcloud/tidbcloud-cli"
+	cliName       = "ticloud"
+	cliNameInTiUP = "cloud"
+	HomePath      = ".ticloud"
+	DevVersion    = "dev"
+	Repo          = "tidbcloud/tidbcloud-cli"
 )
+
+var CliName = cliName
 
 type Config struct {
 	ActiveProfile string
+}
+
+func SetCliName(isUnderTiUP bool) {
+	if isUnderTiUP {
+		CliName = cliNameInTiUP
+	} else {
+		CliName = cliName
+	}
 }
 
 func ValidateProfile(profileName string) error {

--- a/internal/helper.go
+++ b/internal/helper.go
@@ -29,4 +29,5 @@ type Helper struct {
 	QueryPageSize int64
 	IOStreams     *iostream.IOStreams
 	Config        *config.Config
+	IsUnderTiUP   bool
 }


### PR DESCRIPTION
- Use `ticloud` as the CLI name when executing independently.
- Use `cloud` as the CLI name when under TiUP.