### PR TITLE
Using github release rather than tiup mirror

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@
 
 version="0.1.6"
 
-repo='https://tiup-mirrors.pingcap.com/'
+repo='https://github.com/tidbcloud/tidbcloud-cli/releases/download'
 if [ -n "$TICLOUD_MIRRORS" ]; then
     repo=$TICLOUD_MIRRORS
 fi
@@ -49,9 +49,9 @@ bin_dir=$TICLOUD_HOME/bin
 mkdir -p "$bin_dir"
 
 install_binary() {
-    curl -L "$repo/cloud-v${version}-${os}-$arch.tar.gz" -o "/tmp/cloud-v${version}-${os}-$arch.tar.gz" || return 1
-    tar -zxf "/tmp/cloud-v${version}-${os}-$arch.tar.gz" -C "$bin_dir" || return 1
-    rm "/tmp/cloud-v${version}-${os}-$arch.tar.gz"
+    curl -L "$repo/v${version}/ticloud_${version}_${os}_$arch.tar.gz" -o "/tmp/ticloud_${version}_${os}_$arch.tar.gz" || return 1
+    tar -zxf "/tmp/ticloud_${version}_${os}_$arch.tar.gz" -C "$bin_dir" || return 1
+    rm "/tmp/ticloud_${version}_${os}_$arch.tar.gz"
     return 0
 }
 


### PR DESCRIPTION
We meet the situation when installing ticloud in GitHub action failed because can't download the correct archives from TiUP mirror.
So we change the download site from TiUP mirror to GitHub release.
### Download archive in GitHub action(failed):
![84f6b154-9039-4726-86b6-90089643e042](https://user-images.githubusercontent.com/17768378/209604750-e6399d1f-1d69-473d-b2cd-5b91b9158117.jpeg)
### Download archive in local env(success):
![47b15b36-4573-4ac5-b942-672f9ead56ec](https://user-images.githubusercontent.com/17768378/209604787-e3dd381f-c591-43b4-afbd-0559d6cc9a9f.jpeg)
