### PR TITLE
Forbid config name with dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ ticloud config create
 tiup cloud config create
 ```
 
+> :information_source: The config name **MUST NOT** contain '.'
+
 ### Create a cluster
 
 ```shell

--- a/internal/cli/config/create.go
+++ b/internal/cli/config/create.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	"tidbcloud-cli/internal"
 	"tidbcloud-cli/internal/config"
@@ -163,7 +164,7 @@ func CreateCmd(h *internal.Helper) *cobra.Command {
 		},
 	}
 
-	createCmd.Flags().String(flag.ProfileName, "", "the name of the profile to be created")
+	createCmd.Flags().String(flag.ProfileName, "", "the name of the profile, must not contain '.'")
 	createCmd.Flags().String(flag.PublicKey, "", "the public key of the TiDB Cloud API")
 	createCmd.Flags().String(flag.PrivateKey, "", "the private key of the TiDB Cloud API")
 	return createCmd
@@ -187,6 +188,13 @@ func initialDeletionInputModel() ui.TextInputModel {
 			t.Focus()
 			t.PromptStyle = config.FocusedStyle
 			t.TextStyle = config.FocusedStyle
+			t.Placeholder = "Profile Name must not contain '.'"
+			t.Validate = func(value string) error {
+				if strings.Contains(value, ".") {
+					return fmt.Errorf("profile name cannot contain '.'")
+				}
+				return nil
+			}
 		case publicKeyIdx:
 			t.Placeholder = "Public Key"
 			t.CharLimit = 128


### PR DESCRIPTION
`github.com/spf13/viper` uses the dot as the key delimiter, in `ticloud`, the config name is saved as a key. So we should forbid config name with dot unless `ticloud config` can't work properly.