### PR TITLE
Fix error when using `config edit` in Windows

### DIFF
--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -31,7 +31,7 @@ func ConfigCmd(h *internal.Helper) *cobra.Command {
 	configCmd.AddCommand(DeleteCmd(h))
 	configCmd.AddCommand(SetCmd(h))
 	configCmd.AddCommand(UseCmd(h))
-	configCmd.AddCommand(EditCmd())
+	configCmd.AddCommand(EditCmd(h))
 	configCmd.AddCommand(DescribeCmd(h))
 	return configCmd
 }

--- a/internal/cli/config/edit.go
+++ b/internal/cli/config/edit.go
@@ -39,7 +39,7 @@ func EditCmd(h *internal.Helper) *cobra.Command {
   $ %[1]s config edit`, config.CliName),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if runtime.GOOS == "windows" {
-				fmt.Fprintln(h.IOStreams.Out, color.GreenString("Currently, open config file is not supported in Windows.\nThe config file path is %s", viper.ConfigFileUsed()))
+				fmt.Fprintln(h.IOStreams.Out, color.YellowString("Currently, opening config file is not supported in Windows.\nThe config file path is %s", viper.ConfigFileUsed()))
 				return nil
 			}
 

--- a/internal/cli/config/edit.go
+++ b/internal/cli/config/edit.go
@@ -17,9 +17,12 @@ package config
 import (
 	"fmt"
 	"os"
+	"runtime"
 
+	"tidbcloud-cli/internal"
 	"tidbcloud-cli/internal/config"
 
+	"github.com/fatih/color"
 	"github.com/juju/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -28,13 +31,18 @@ import (
 
 const defaultEditor = "vi"
 
-func EditCmd() *cobra.Command {
+func EditCmd(h *internal.Helper) *cobra.Command {
 	var listCmd = &cobra.Command{
 		Use:   "edit",
 		Short: "Open the config file with the default text editor",
 		Example: fmt.Sprintf(`  To open the config
   $ %[1]s config edit`, config.CliName),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if runtime.GOOS == "windows" {
+				fmt.Fprintln(h.IOStreams.Out, color.GreenString("Currently, open config file is not supported in Windows.\nThe config file path is %s", viper.ConfigFileUsed()))
+				return nil
+			}
+
 			c := exec.Command(defaultEditor, viper.ConfigFileUsed()) //nolint:gosec
 			c.Stdin = os.Stdin
 			c.Stdout = os.Stdout


### PR DESCRIPTION
- If using `config edit` in the Unix system, open the config file with the vi editor.
- If using `config edit` in Windows, print the config file path instead.