### PR TITLE
Fix channel leak

### DIFF
--- a/internal/cli/cluster/create.go
+++ b/internal/cli/cluster/create.go
@@ -294,9 +294,10 @@ func CreateAndWaitReady(h *internal.Helper, d cloud.TiDBCloudClient, projectID s
 		return errors.Trace(err)
 	}
 	newClusterID := *createClusterResult.GetPayload().ID
-	ticker := time.NewTicker(1 * time.Second)
 
 	fmt.Fprintln(h.IOStreams.Out, "... Waiting for cluster to be ready")
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
 	timer := time.After(2 * time.Minute)
 	for {
 		select {
@@ -328,6 +329,7 @@ func CreateAndSpinnerWait(d cloud.TiDBCloudClient, projectID string, clusterDefB
 		newClusterID := *createClusterResult.GetPayload().ID
 
 		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
 		timer := time.After(2 * time.Minute)
 		for {
 			select {

--- a/internal/cli/cluster/delete.go
+++ b/internal/cli/cluster/delete.go
@@ -156,6 +156,7 @@ func DeleteCmd(h *internal.Helper) *cobra.Command {
 			}
 
 			ticker := time.NewTicker(1 * time.Second)
+			defer ticker.Stop()
 			timer := time.After(2 * time.Minute)
 			for {
 				select {

--- a/internal/cli/dataimport/start/local.go
+++ b/internal/cli/dataimport/start/local.go
@@ -328,7 +328,7 @@ func waitUploadOp(h *internal.Helper, d cloud.TiDBCloudClient, url *string, uplo
 
 func spinnerWaitUploadOp(h *internal.Helper, d cloud.TiDBCloudClient, url *string, uploadFile *os.File, size int64) error {
 	task := func() tea.Msg {
-		errChan := make(chan error)
+		errChan := make(chan error, 1)
 
 		go func() {
 			err := d.PreSignedUrlUpload(url, uploadFile, size)
@@ -342,6 +342,7 @@ func spinnerWaitUploadOp(h *internal.Helper, d cloud.TiDBCloudClient, url *strin
 		}()
 
 		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
 		timer := time.After(2 * time.Minute)
 		for {
 			select {

--- a/internal/cli/dataimport/start/start.go
+++ b/internal/cli/dataimport/start/start.go
@@ -74,7 +74,7 @@ func waitStartOp(h *internal.Helper, d cloud.TiDBCloudClient, params *importOp.C
 
 func spinnerWaitStartOp(h *internal.Helper, d cloud.TiDBCloudClient, params *importOp.CreateImportParams) error {
 	task := func() tea.Msg {
-		errChan := make(chan error)
+		errChan := make(chan error, 1)
 
 		go func() {
 			res, err := d.CreateImport(params)
@@ -88,6 +88,7 @@ func spinnerWaitStartOp(h *internal.Helper, d cloud.TiDBCloudClient, params *imp
 		}()
 
 		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
 		timer := time.After(2 * time.Minute)
 		for {
 			select {

--- a/internal/cli/update/update.go
+++ b/internal/cli/update/update.go
@@ -104,7 +104,7 @@ func updateAndWaitReady(h *internal.Helper, newRelease *github.ReleaseInfo) erro
 
 func updateAndSpinnerWait(h *internal.Helper, newRelease *github.ReleaseInfo) error {
 	task := func() tea.Msg {
-		res := make(chan error)
+		res := make(chan error, 1)
 
 		go func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
@@ -133,6 +133,7 @@ func updateAndSpinnerWait(h *internal.Helper, newRelease *github.ReleaseInfo) er
 		}()
 
 		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
 		for {
 			select {
 			case err := <-res:


### PR DESCRIPTION
- Use a buffered channel to avoid channel leak when the receiver exits before the sender, in which case the sender will block.
- Defer ticker. Stop () to close the ticker to lease the ticker channel.