### PR TITLE
Optimize create/delete output

### DIFF
--- a/internal/cli/branch/create.go
+++ b/internal/cli/branch/create.go
@@ -177,7 +177,7 @@ func CreateAndWaitReady(h *internal.Helper, d cloud.TiDBCloudClient, params *bra
 	for {
 		select {
 		case <-timer:
-			return errors.New("Timeout waiting for branch to be ready, please check status on dashboard.")
+			return errors.New(fmt.Sprintf("Timeout waiting for branch %s to be ready, please check status on dashboard.", newBranchID))
 		case <-ticker.C:
 			clusterResult, err := d.GetBranch(branchApi.NewGetBranchParams().
 				WithClusterID(params.ClusterID).
@@ -209,7 +209,7 @@ func CreateAndSpinnerWait(ctx context.Context, d cloud.TiDBCloudClient, params *
 		for {
 			select {
 			case <-timer:
-				return ui.Result("Timeout waiting for branch to be ready, please check status on dashboard.")
+				return ui.Result(fmt.Sprintf("Timeout waiting for branch %s to be ready, please check status on dashboard.", newBranchID))
 			case <-ticker.C:
 				clusterResult, err := d.GetBranch(branchApi.NewGetBranchParams().
 					WithClusterID(params.ClusterID).

--- a/internal/cli/branch/delete.go
+++ b/internal/cli/branch/delete.go
@@ -156,7 +156,7 @@ func DeleteCmd(h *internal.Helper) *cobra.Command {
 			for {
 				select {
 				case <-timer:
-					return errors.New("timeout waiting for deleting branch, please check status on dashboard")
+					return errors.New(fmt.Sprintf("timeout waiting for deleting branch %s, please check status on dashboard", branchID))
 				case <-ticker.C:
 					_, err := d.GetBranch(branchApi.NewGetBranchParams().
 						WithClusterID(clusterID).

--- a/internal/cli/cluster/create.go
+++ b/internal/cli/cluster/create.go
@@ -311,7 +311,7 @@ func CreateAndWaitReady(h *internal.Helper, d cloud.TiDBCloudClient, projectID s
 	for {
 		select {
 		case <-timer:
-			return errors.New("Timeout waiting for cluster to be ready, please check status on dashboard.")
+			return errors.New(fmt.Sprintf("Timeout waiting for cluster %s to be ready, please check status on dashboard.", newClusterID))
 		case <-ticker.C:
 			clusterResult, err := d.GetCluster(clusterApi.NewGetClusterParams().
 				WithClusterID(newClusterID).
@@ -343,7 +343,7 @@ func CreateAndSpinnerWait(ctx context.Context, d cloud.TiDBCloudClient, projectI
 		for {
 			select {
 			case <-timer:
-				return ui.Result("Timeout waiting for cluster to be ready, please check status on dashboard.")
+				return ui.Result(fmt.Sprintf("Timeout waiting for cluster %s to be ready, please check status on dashboard.", newClusterID))
 			case <-ticker.C:
 				clusterResult, err := d.GetCluster(clusterApi.NewGetClusterParams().
 					WithClusterID(newClusterID).
@@ -361,7 +361,7 @@ func CreateAndSpinnerWait(ctx context.Context, d cloud.TiDBCloudClient, projectI
 		}
 	}
 
-	p := tea.NewProgram(ui.InitialSpinnerModel(task, "Waiting for cluster to be ready"))
+	p := tea.NewProgram(ui.InitialSpinnerModel(task, fmt.Sprintf("Waiting for cluster to be ready")))
 	createModel, err := p.StartReturningModel()
 	if err != nil {
 		return errors.Trace(err)

--- a/internal/cli/cluster/create.go
+++ b/internal/cli/cluster/create.go
@@ -361,7 +361,7 @@ func CreateAndSpinnerWait(ctx context.Context, d cloud.TiDBCloudClient, projectI
 		}
 	}
 
-	p := tea.NewProgram(ui.InitialSpinnerModel(task, fmt.Sprintf("Waiting for cluster to be ready")))
+	p := tea.NewProgram(ui.InitialSpinnerModel(task, "Waiting for cluster to be ready"))
 	createModel, err := p.StartReturningModel()
 	if err != nil {
 		return errors.Trace(err)

--- a/internal/cli/cluster/delete.go
+++ b/internal/cli/cluster/delete.go
@@ -166,14 +166,14 @@ func DeleteCmd(h *internal.Helper) *cobra.Command {
 			for {
 				select {
 				case <-timer:
-					return errors.New("timeout waiting for deleting cluster, please check status on dashboard")
+					return errors.New(fmt.Sprintf("timeout waiting for deleting cluster %s, please check status on dashboard", clusterID))
 				case <-ticker.C:
 					_, err := d.GetCluster(clusterApi.NewGetClusterParams().
 						WithClusterID(clusterID).
 						WithProjectID(projectID))
 					if err != nil {
 						if _, ok := err.(*clusterApi.GetClusterNotFound); ok {
-							fmt.Fprintln(h.IOStreams.Out, color.GreenString("cluster deleted"))
+							fmt.Fprintln(h.IOStreams.Out, color.GreenString(fmt.Sprintf("cluster %s deleted", clusterID)))
 							return nil
 						}
 						return errors.Trace(err)

--- a/internal/cli/cluster/delete_test.go
+++ b/internal/cli/cluster/delete_test.go
@@ -74,7 +74,7 @@ func (suite *DeleteClusterSuite) TestDeleteClusterArgs() {
 		{
 			name:         "delete cluster success",
 			args:         []string{"--project-id", projectID, "--cluster-id", clusterID, "--force"},
-			stdoutString: "cluster deleted\n",
+			stdoutString: fmt.Sprintf("cluster %s deleted\n", clusterID),
 		},
 		{
 			name: "delete cluster without force",
@@ -84,7 +84,7 @@ func (suite *DeleteClusterSuite) TestDeleteClusterArgs() {
 		{
 			name:         "delete cluster with output flag",
 			args:         []string{"-p", projectID, "-c", clusterID, "--force"},
-			stdoutString: "cluster deleted\n",
+			stdoutString: fmt.Sprintf("cluster %s deleted\n", clusterID),
 		},
 		{
 			name: "delete cluster without required project id",


### PR DESCRIPTION
## What is the purpose of the change

Add id infomation

## Brief change log

<!-- *(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache* -->
