### PR TITLE
Optimize branch delete to avoid too many 404

### DIFF
--- a/internal/cli/branch/delete.go
+++ b/internal/cli/branch/delete.go
@@ -16,9 +16,6 @@ package branch
 
 import (
 	"fmt"
-	"strings"
-	"time"
-
 	"tidbcloud-cli/internal"
 	"tidbcloud-cli/internal/config"
 	"tidbcloud-cli/internal/flag"
@@ -149,27 +146,9 @@ func DeleteCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return errors.Trace(err)
 			}
-
-			ticker := time.NewTicker(1 * time.Second)
-			defer ticker.Stop()
-			timer := time.After(2 * time.Minute)
-			for {
-				select {
-				case <-timer:
-					return errors.New("timeout waiting for deleting branch, please check status on dashboard")
-				case <-ticker.C:
-					_, err := d.GetBranch(branchApi.NewGetBranchParams().
-						WithClusterID(clusterID).
-						WithBranchID(branchID))
-					if err != nil {
-						if strings.Contains(err.Error(), "404") {
-							fmt.Fprintln(h.IOStreams.Out, color.GreenString("branch %s deleted", branchID))
-							return nil
-						}
-						return errors.Trace(err)
-					}
-				}
-			}
+			// print success for delete branch is a sync operation
+			fmt.Fprintln(h.IOStreams.Out, color.GreenString("branch %s deleted", branchID))
+			return nil
 		},
 	}
 

--- a/internal/cli/branch/delete_test.go
+++ b/internal/cli/branch/delete_test.go
@@ -16,7 +16,6 @@ package branch
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -61,9 +60,6 @@ func (suite *DeleteBranchSuite) TestDeleteBranchArgs() {
 	suite.mockClient.On("DeleteBranch", branchApi.NewDeleteBranchParams().
 		WithBranchID(branchID).WithClusterID(clusterID)).
 		Return(&branchApi.DeleteBranchOK{}, nil)
-	suite.mockClient.On("GetBranch", branchApi.NewGetBranchParams().
-		WithBranchID(branchID).WithClusterID(clusterID)).
-		Return(nil, errors.New("404"))
 
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## What is the purpose of the change

Optimize branch delete to avoid too many 404

![image](https://github.com/tidbcloud/tidbcloud-cli/assets/52435083/1fd06a85-7399-4355-8011-98df162a0743)


<!-- (For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).) -->

## Brief change log

<!-- *(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache* -->
