### PR TITLE
Fix: reply content has links

### DIFF
--- a/internal/cli/ai/ai.go
+++ b/internal/cli/ai/ai.go
@@ -122,18 +122,19 @@ func AICmd(h *internal.Helper) *cobra.Command {
 						}
 					}
 
-					content := chat.Payload.Content + "\n\n"
+					linkContent := "\n\n"
 					for i, link := range chat.Payload.Links {
-						content = fmt.Sprintf("%s[%d] [%s](%s)\n", content, i+1, link.Title, link.Link)
+						linkContent = fmt.Sprintf("%s[%d] [%s](%s)\n", linkContent, i+1, link.Title, link.Link)
 					}
 
 					// Replace occurrences of [^\d+] with [\d+] for better user comprehension.
-					content = re.ReplaceAllString(content, "[$1]")
+					content := re.ReplaceAllString(chat.Payload.Content, "[$1]")
 
 					return ui.EndSendingMsg{
 						Msg: ui.ChatMessage{
-							Role:    ui.RoleBot,
-							Content: content,
+							Role:        ui.RoleBot,
+							Content:     content,
+							LinkContent: linkContent,
 						},
 					}
 				}

--- a/internal/ui/chat_box_model.go
+++ b/internal/ui/chat_box_model.go
@@ -40,8 +40,9 @@ const (
 )
 
 type ChatMessage struct {
-	Role    Role
-	Content string
+	Role        Role
+	Content     string
+	LinkContent string
 }
 
 type ChatBoxModel struct {
@@ -212,7 +213,7 @@ func (m ChatBoxModel) RenderChatLog() string {
 		// Due to a bug in the formatting of Chinese characters (see https://github.com/charmbracelet/glamour/pull/249),
 		// glamour cannot correctly word-wrap Chinese characters. Therefore, we need to wrap the string before rendering it.
 		// Because glamour will add some extra characters to the string, we need to subtract the length of those characters.
-		s := util.String(message.Content, maxWidth-6)
+		s := util.String(message.Content+message.LinkContent, maxWidth-6)
 		out, _ := r.Render(s)
 
 		var who string


### PR DESCRIPTION
## What is the purpose of the change

reply's content has links, which is redundant.

## Brief change log

- Ask questions without links so that reply's content has no links
