### PR TITLE
Update branch swagger

### DIFF
--- a/internal/cli/serverless/branch/connect.go
+++ b/internal/cli/serverless/branch/connect.go
@@ -194,8 +194,8 @@ the connection forces the [ANSI SQL mode](https://dev.mysql.com/doc/refman/8.0/e
 			if err != nil {
 				return errors.Trace(err)
 			}
-			host = branchInfo.Payload.Endpoints.PublicEndpoint.Host
-			port = strconv.Itoa(int(branchInfo.Payload.Endpoints.PublicEndpoint.Port))
+			host = branchInfo.Payload.Endpoints.Public.Host
+			port = strconv.Itoa(int(branchInfo.Payload.Endpoints.Public.Port))
 			name = *branchInfo.Payload.DisplayName
 			if userName == "" {
 				userName = fmt.Sprintf("%s.root", branchInfo.Payload.UserPrefix)

--- a/internal/cli/serverless/branch/connectinfo.go
+++ b/internal/cli/serverless/branch/connectinfo.go
@@ -193,7 +193,7 @@ func ConnectInfoCmd(h *internal.Helper) *cobra.Command {
 			// Get connect parameter
 			defaultUser := fmt.Sprintf("%s.root", branchInfo.Payload.UserPrefix)
 			host := branchInfo.Payload.Endpoints.Public.Host
-			port := strconv.Itoa(int(branchInfo.Payload.Endpoints.Private.Port))
+			port := strconv.Itoa(int(branchInfo.Payload.Endpoints.Public.Port))
 
 			// Get connection string
 			connectInfo, err := cloud.RetrieveConnectInfo(d)

--- a/internal/cli/serverless/branch/connectinfo.go
+++ b/internal/cli/serverless/branch/connectinfo.go
@@ -192,8 +192,8 @@ func ConnectInfoCmd(h *internal.Helper) *cobra.Command {
 
 			// Get connect parameter
 			defaultUser := fmt.Sprintf("%s.root", branchInfo.Payload.UserPrefix)
-			host := branchInfo.Payload.Endpoints.PublicEndpoint.Host
-			port := strconv.Itoa(int(branchInfo.Payload.Endpoints.PublicEndpoint.Port))
+			host := branchInfo.Payload.Endpoints.Public.Host
+			port := strconv.Itoa(int(branchInfo.Payload.Endpoints.Private.Port))
 
 			// Get connection string
 			connectInfo, err := cloud.RetrieveConnectInfo(d)

--- a/internal/cli/serverless/branch/describe_test.go
+++ b/internal/cli/serverless/branch/describe_test.go
@@ -42,7 +42,7 @@ const getBranchResultStr = `{
   "createdBy": "yuhang.shi@pingcap.com",
   "displayName": "t2",
   "endpoints": {
-    "publicEndpoint": {
+    "public": {
       "host": "gateway01.us-east-1.dev.shared.aws.tidbcloud.com",
       "port": 4000
     }

--- a/pkg/tidbcloud/v1beta1/branch/branch.swagger.json
+++ b/pkg/tidbcloud/v1beta1/branch/branch.swagger.json
@@ -202,11 +202,11 @@
     "BranchEndpoints": {
       "type": "object",
       "properties": {
-        "publicEndpoint": {
+        "public": {
           "$ref": "#/definitions/EndpointsPublic",
           "description": "Optional . Public Endpoint for this branch."
         },
-        "privateEndpoint": {
+        "private": {
           "$ref": "#/definitions/EndpointsPrivate",
           "description": "Optional . Private Endpoint for this branch."
         }
@@ -317,7 +317,7 @@
     "PrivateGCP": {
       "type": "object",
       "properties": {
-        "targetServiceAccount": {
+        "serviceAttachmentName": {
           "type": "string",
           "description": "Output Only. Target Service Account for Private Link Service.",
           "readOnly": true

--- a/pkg/tidbcloud/v1beta1/branch/models/branch_endpoints.go
+++ b/pkg/tidbcloud/v1beta1/branch/models/branch_endpoints.go
@@ -19,21 +19,21 @@ import (
 type BranchEndpoints struct {
 
 	// Optional . Private Endpoint for this branch.
-	PrivateEndpoint *EndpointsPrivate `json:"privateEndpoint,omitempty"`
+	Private *EndpointsPrivate `json:"private,omitempty"`
 
 	// Optional . Public Endpoint for this branch.
-	PublicEndpoint *EndpointsPublic `json:"publicEndpoint,omitempty"`
+	Public *EndpointsPublic `json:"public,omitempty"`
 }
 
 // Validate validates this branch endpoints
 func (m *BranchEndpoints) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validatePrivateEndpoint(formats); err != nil {
+	if err := m.validatePrivate(formats); err != nil {
 		res = append(res, err)
 	}
 
-	if err := m.validatePublicEndpoint(formats); err != nil {
+	if err := m.validatePublic(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -43,17 +43,17 @@ func (m *BranchEndpoints) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *BranchEndpoints) validatePrivateEndpoint(formats strfmt.Registry) error {
-	if swag.IsZero(m.PrivateEndpoint) { // not required
+func (m *BranchEndpoints) validatePrivate(formats strfmt.Registry) error {
+	if swag.IsZero(m.Private) { // not required
 		return nil
 	}
 
-	if m.PrivateEndpoint != nil {
-		if err := m.PrivateEndpoint.Validate(formats); err != nil {
+	if m.Private != nil {
+		if err := m.Private.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("privateEndpoint")
+				return ve.ValidateName("private")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("privateEndpoint")
+				return ce.ValidateName("private")
 			}
 			return err
 		}
@@ -62,17 +62,17 @@ func (m *BranchEndpoints) validatePrivateEndpoint(formats strfmt.Registry) error
 	return nil
 }
 
-func (m *BranchEndpoints) validatePublicEndpoint(formats strfmt.Registry) error {
-	if swag.IsZero(m.PublicEndpoint) { // not required
+func (m *BranchEndpoints) validatePublic(formats strfmt.Registry) error {
+	if swag.IsZero(m.Public) { // not required
 		return nil
 	}
 
-	if m.PublicEndpoint != nil {
-		if err := m.PublicEndpoint.Validate(formats); err != nil {
+	if m.Public != nil {
+		if err := m.Public.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("publicEndpoint")
+				return ve.ValidateName("public")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("publicEndpoint")
+				return ce.ValidateName("public")
 			}
 			return err
 		}
@@ -85,11 +85,11 @@ func (m *BranchEndpoints) validatePublicEndpoint(formats strfmt.Registry) error 
 func (m *BranchEndpoints) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.contextValidatePrivateEndpoint(ctx, formats); err != nil {
+	if err := m.contextValidatePrivate(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
-	if err := m.contextValidatePublicEndpoint(ctx, formats); err != nil {
+	if err := m.contextValidatePublic(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -99,19 +99,19 @@ func (m *BranchEndpoints) ContextValidate(ctx context.Context, formats strfmt.Re
 	return nil
 }
 
-func (m *BranchEndpoints) contextValidatePrivateEndpoint(ctx context.Context, formats strfmt.Registry) error {
+func (m *BranchEndpoints) contextValidatePrivate(ctx context.Context, formats strfmt.Registry) error {
 
-	if m.PrivateEndpoint != nil {
+	if m.Private != nil {
 
-		if swag.IsZero(m.PrivateEndpoint) { // not required
+		if swag.IsZero(m.Private) { // not required
 			return nil
 		}
 
-		if err := m.PrivateEndpoint.ContextValidate(ctx, formats); err != nil {
+		if err := m.Private.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("privateEndpoint")
+				return ve.ValidateName("private")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("privateEndpoint")
+				return ce.ValidateName("private")
 			}
 			return err
 		}
@@ -120,19 +120,19 @@ func (m *BranchEndpoints) contextValidatePrivateEndpoint(ctx context.Context, fo
 	return nil
 }
 
-func (m *BranchEndpoints) contextValidatePublicEndpoint(ctx context.Context, formats strfmt.Registry) error {
+func (m *BranchEndpoints) contextValidatePublic(ctx context.Context, formats strfmt.Registry) error {
 
-	if m.PublicEndpoint != nil {
+	if m.Public != nil {
 
-		if swag.IsZero(m.PublicEndpoint) { // not required
+		if swag.IsZero(m.Public) { // not required
 			return nil
 		}
 
-		if err := m.PublicEndpoint.ContextValidate(ctx, formats); err != nil {
+		if err := m.Public.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("publicEndpoint")
+				return ve.ValidateName("public")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("publicEndpoint")
+				return ce.ValidateName("public")
 			}
 			return err
 		}

--- a/pkg/tidbcloud/v1beta1/branch/models/private_g_c_p.go
+++ b/pkg/tidbcloud/v1beta1/branch/models/private_g_c_p.go
@@ -21,7 +21,7 @@ type PrivateGCP struct {
 
 	// Output Only. Target Service Account for Private Link Service.
 	// Read Only: true
-	TargetServiceAccount string `json:"targetServiceAccount,omitempty"`
+	ServiceAttachmentName string `json:"serviceAttachmentName,omitempty"`
 }
 
 // Validate validates this private g c p
@@ -33,7 +33,7 @@ func (m *PrivateGCP) Validate(formats strfmt.Registry) error {
 func (m *PrivateGCP) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.contextValidateTargetServiceAccount(ctx, formats); err != nil {
+	if err := m.contextValidateServiceAttachmentName(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -43,9 +43,9 @@ func (m *PrivateGCP) ContextValidate(ctx context.Context, formats strfmt.Registr
 	return nil
 }
 
-func (m *PrivateGCP) contextValidateTargetServiceAccount(ctx context.Context, formats strfmt.Registry) error {
+func (m *PrivateGCP) contextValidateServiceAttachmentName(ctx context.Context, formats strfmt.Registry) error {
 
-	if err := validate.ReadOnly(ctx, "targetServiceAccount", "body", string(m.TargetServiceAccount)); err != nil {
+	if err := validate.ReadOnly(ctx, "serviceAttachmentName", "body", string(m.ServiceAttachmentName)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

<!-- (For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).) -->

## Brief change log

<!-- *(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache* -->
