### PR TITLE
Fix export typo

### DIFF
--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -35,7 +35,7 @@ const (
 func AuthCmd(h *internal.Helper) *cobra.Command {
 	var authCmd = &cobra.Command{
 		Use:   "auth",
-		Short: "Login and logout via the PlanetScale API",
+		Short: "Login and logout via the TiDB Cloud API",
 	}
 
 	authCmd.AddCommand(LoginCmd(h))

--- a/internal/cli/auth/logout.go
+++ b/internal/cli/auth/logout.go
@@ -40,8 +40,8 @@ func LogoutCmd(h *internal.Helper) *cobra.Command {
 	}
 	var logoutCmd = &cobra.Command{
 		Use:   "logout",
-		Short: "Log out of the CLI",
-		Example: fmt.Sprintf(`  To log out of the CLI:
+		Short: "Log out of the TiDB Cloud",
+		Example: fmt.Sprintf(`  To log out of the TiDB Cloud:
   $ %[1]s auth logout`, config.CliName),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			debug, err := cmd.Flags().GetBool(flag.Debug)

--- a/internal/cli/serverless/export/create.go
+++ b/internal/cli/serverless/export/create.go
@@ -121,7 +121,7 @@ func CreateCmd(h *internal.Helper) *cobra.Command {
   $ %[1]s serverless export create -c <cluster-id> --database <database> --table <table>
 
   Create an export with s3 type in non-interactive mode:
-  $ %[1]s serverless export create -c <cluster-id> --bucket-uri <bucket-uri> --access-key-id <access-key-id> --secret-access-key <secret-access-key>`,
+  $ %[1]s serverless export create -c <cluster-id> --s3.bucket-uri <bucket-uri> --s3.access-key-id <access-key-id> --s3.secret-access-key <secret-access-key>`,
 			config.CliName),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.MarkInteractive(cmd)
@@ -299,7 +299,7 @@ func CreateCmd(h *internal.Helper) *cobra.Command {
 	createCmd.Flags().String(flag.S3BucketURI, "", "The bucket URI of the S3. Required when target type is S3")
 	createCmd.Flags().String(flag.S3AccessKeyID, "", "The access key ID of the S3 bucket. Required when target type is S3")
 	createCmd.Flags().String(flag.S3SecretAccessKey, "", "The secret access key of the S3 bucket. Required when target type is S3")
-	createCmd.Flags().String(flag.Compression, "", "The compression algorithm of the export file. One of [\"GZIP\" \"SNAPPY\" \"ZSTD\" \"NONE\"]")
+	createCmd.Flags().String(flag.Compression, "GZIP", "The compression algorithm of the export file. One of [\"GZIP\" \"SNAPPY\" \"ZSTD\" \"NONE\"]")
 	return createCmd
 }
 

--- a/internal/cli/serverless/export/download.go
+++ b/internal/cli/serverless/export/download.go
@@ -200,8 +200,8 @@ func DownloadCmd(h *internal.Helper) *cobra.Command {
 		},
 	}
 
-	downloadCmd.Flags().StringP(flag.ExportID, flag.ExportIDShort, "", "The ID of the export to be described")
-	downloadCmd.Flags().StringP(flag.ClusterID, flag.ClusterIDShort, "", "The cluster ID of the export to be described")
+	downloadCmd.Flags().StringP(flag.ExportID, flag.ExportIDShort, "", "The ID of the export")
+	downloadCmd.Flags().StringP(flag.ClusterID, flag.ClusterIDShort, "", "The cluster ID of the export")
 	downloadCmd.Flags().String(flag.OutputPath, "", "Where you want to download to. If not specified, download to the current directory")
 	downloadCmd.Flags().BoolVar(&autoApprove, flag.AutoApprove, false, "Download without confirmation")
 	downloadCmd.MarkFlagsRequiredTogether(flag.ExportID, flag.ClusterID)


### PR DESCRIPTION
## What is the purpose of the change

<!-- (For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).) -->

## Brief change log

<!-- *(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache* -->
