### PR TITLE
Polish help message

### DIFF
--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -46,7 +46,7 @@ func LoginCmd(h *internal.Helper) *cobra.Command {
 	var loginCmd = &cobra.Command{
 		Use:   "login",
 		Short: "Authenticate with TiDB Cloud",
-		Example: fmt.Sprintf(`  To start the login for your account:
+		Example: fmt.Sprintf(`  To log into TiDB Cloud::
   $ %[1]s auth login`, config.CliName),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			debug, err := cmd.Flags().GetBool(flag.Debug)

--- a/internal/cli/serverless/backup/backup.go
+++ b/internal/cli/serverless/backup/backup.go
@@ -23,7 +23,7 @@ import (
 func Cmd(h *internal.Helper) *cobra.Command {
 	var backupCmd = &cobra.Command{
 		Use:   "backup",
-		Short: "Manage serverless cluster backups",
+		Short: "Manage TiDB Serverless backups",
 	}
 
 	backupCmd.AddCommand(ListCmd(h))

--- a/internal/cli/serverless/backup/delete.go
+++ b/internal/cli/serverless/backup/delete.go
@@ -72,7 +72,7 @@ func DeleteCmd(h *internal.Helper) *cobra.Command {
 	var force bool
 	var deleteCmd = &cobra.Command{
 		Use:   "delete",
-		Short: "Delete a serverless cluster backup",
+		Short: "Delete a backup",
 		Args:  cobra.NoArgs,
 		Example: fmt.Sprintf(`  Delete a backup in interactive mode:
   $ %[1]s serverless backup delete

--- a/internal/cli/serverless/backup/describe.go
+++ b/internal/cli/serverless/backup/describe.go
@@ -67,7 +67,7 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 
 	var describeCmd = &cobra.Command{
 		Use:     "describe",
-		Short:   "Describe a serverless cluster backup",
+		Short:   "Describe a backup",
 		Aliases: []string{"get"},
 		Args:    cobra.NoArgs,
 		Example: fmt.Sprintf(`  Get the backup in interactive mode:

--- a/internal/cli/serverless/backup/list.go
+++ b/internal/cli/serverless/backup/list.go
@@ -66,7 +66,7 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 
 	var listCmd = &cobra.Command{
 		Use:   "list",
-		Short: "List serverless cluster backups",
+		Short: "List backups",
 		Example: fmt.Sprintf(`  List the backups in interactive mode:
   $ %[1]s serverless backup list
 

--- a/internal/cli/serverless/branch/branch.go
+++ b/internal/cli/serverless/branch/branch.go
@@ -23,7 +23,7 @@ import (
 func Cmd(h *internal.Helper) *cobra.Command {
 	var branchCmd = &cobra.Command{
 		Use:   "branch",
-		Short: "Manage serverless cluster branches",
+		Short: "Manage TiDB Serverless branches",
 	}
 
 	branchCmd.AddCommand(CreateCmd(h))

--- a/internal/cli/serverless/create.go
+++ b/internal/cli/serverless/create.go
@@ -80,15 +80,15 @@ func CreateCmd(h *internal.Helper) *cobra.Command {
 
 	var createCmd = &cobra.Command{
 		Use:         "create",
-		Short:       "Create a serverless cluster",
+		Short:       "Create a TiDB Serverless cluster",
 		Annotations: make(map[string]string),
-		Example: fmt.Sprintf(`  Create a serverless cluster in interactive mode:
+		Example: fmt.Sprintf(`  Create a TiDB Serverless cluster in interactive mode:
   $ %[1]s serverless create
 
-  Create a serverless cluster of the default ptoject in non-interactive mode:
+  Create a TiDB Serverless cluster of the default ptoject in non-interactive mode:
   $ %[1]s serverless create --display-name <cluster-name> --region <region>
 
-  Create a serverless cluster in non-interactive mode:
+  Create a TiDB Serverless cluster in non-interactive mode:
   $ %[1]s serverless create --project-id <project-id> --display-name <cluster-name> --region <region>`,
 			config.CliName),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/serverless/dataimport/import.go
+++ b/internal/cli/serverless/dataimport/import.go
@@ -24,7 +24,7 @@ import (
 func ImportCmd(h *internal.Helper) *cobra.Command {
 	var importCmd = &cobra.Command{
 		Use:   "import",
-		Short: "Import data into serverless cluster",
+		Short: "Manage TiDB Serverless data imports",
 	}
 
 	importCmd.AddCommand(ListCmd(h))

--- a/internal/cli/serverless/dataimport/start/start.go
+++ b/internal/cli/serverless/dataimport/start/start.go
@@ -85,13 +85,13 @@ func StartCmd(h *internal.Helper) *cobra.Command {
 		Example: fmt.Sprintf(`  Start an import task in interactive mode:
   $ %[1]s serverless import start
 
-  Start an local import task in non-interactive mode:
+  Start a local import task in non-interactive mode:
   $ %[1]s serverless import start --local.file-path <file-path> --cluster-id <cluster-id> --file-type <file-type> --local.target-database <target-database> --local.target-table <target-table>
 
-  Start an local import task with custom upload concurrency:
+  Start a local import task with custom upload concurrency:
   $ %[1]s serverless import start --local.file-path <file-path> --cluster-id <cluster-id> --file-type <file-type> --local.target-database <target-database> --local.target-table <target-table> --local.concurrency 10
 	
-  Start an local import task with custom CSV format:
+  Start a local import task with custom CSV format:
   $ %[1]s serverless import start --local.file-path <file-path> --cluster-id <cluster-id> --file-type CSV --local.target-database <target-database> --local.target-table <target-table> --csv.separator \" --csv.delimiter \' --csv.backslash-escape=false --csv.trim-last-separator=true
 `,
 			config.CliName),

--- a/internal/cli/serverless/delete.go
+++ b/internal/cli/serverless/delete.go
@@ -52,12 +52,12 @@ func DeleteCmd(h *internal.Helper) *cobra.Command {
 	var force bool
 	var deleteCmd = &cobra.Command{
 		Use:         "delete",
-		Short:       "Delete a serverless cluster",
+		Short:       "Delete a TiDB Serverless cluster",
 		Annotations: make(map[string]string),
-		Example: fmt.Sprintf(`  Delete a serverless cluster in interactive mode:
+		Example: fmt.Sprintf(`  Delete a TiDB Serverless cluster in interactive mode:
  $ %[1]s serverless delete
 
- Delete a serverless cluster in non-interactive mode:
+ Delete a TiDB Serverless cluster in non-interactive mode:
  $ %[1]s serverless delete -c <cluster-id>`, config.CliName),
 		Aliases: []string{"rm"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/serverless/describe.go
+++ b/internal/cli/serverless/describe.go
@@ -46,13 +46,13 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 
 	var describeCmd = &cobra.Command{
 		Use:         "describe",
-		Short:       "Describe a serverless cluster",
+		Short:       "Describe a TiDB Serverless cluster",
 		Aliases:     []string{"get"},
 		Annotations: make(map[string]string),
-		Example: fmt.Sprintf(`  Get a serverless cluster in interactive mode:
+		Example: fmt.Sprintf(`  Get a TiDB Serverless cluster in interactive mode:
  $ %[1]s serverless describe
 
- Get a serverless cluster in non-interactive mode:
+ Get a TiDB Serverless cluster in non-interactive mode:
  $ %[1]s serverless describe -c <cluster-id>`, config.CliName),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flags := opts.NonInteractiveFlags()

--- a/internal/cli/serverless/export/cancel.go
+++ b/internal/cli/serverless/export/cancel.go
@@ -73,7 +73,7 @@ func CancelCmd(h *internal.Helper) *cobra.Command {
 	var force bool
 	var cancelCmd = &cobra.Command{
 		Use:   "cancel",
-		Short: "Cancel a serverless cluster export",
+		Short: "Cancel an export task",
 		Args:  cobra.NoArgs,
 		Example: fmt.Sprintf(`  Cancel an export in interactive mode:
   $ %[1]s serverless export cancel

--- a/internal/cli/serverless/export/create.go
+++ b/internal/cli/serverless/export/create.go
@@ -112,7 +112,7 @@ func CreateCmd(h *internal.Helper) *cobra.Command {
 
 	var createCmd = &cobra.Command{
 		Use:   "create",
-		Short: "Create a serverless cluster export",
+		Short: "Export data from a TiDB Serverless cluster",
 		Args:  cobra.NoArgs,
 		Example: fmt.Sprintf(`  Create an export in interactive mode:
   $ %[1]s serverless export create

--- a/internal/cli/serverless/export/describe.go
+++ b/internal/cli/serverless/export/describe.go
@@ -67,7 +67,7 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 
 	var describeCmd = &cobra.Command{
 		Use:     "describe",
-		Short:   "Describe a serverless cluster export",
+		Short:   "Describe an export task",
 		Aliases: []string{"get"},
 		Args:    cobra.NoArgs,
 		Example: fmt.Sprintf(`  Get an export in interactive mode:

--- a/internal/cli/serverless/export/download.go
+++ b/internal/cli/serverless/export/download.go
@@ -92,7 +92,7 @@ func DownloadCmd(h *internal.Helper) *cobra.Command {
 
 	var downloadCmd = &cobra.Command{
 		Use:   "download",
-		Short: "Download the local type export",
+		Short: "Download the exported data",
 		Args:  cobra.NoArgs,
 		Example: fmt.Sprintf(`  Download the local type export in interactive mode:
   $ %[1]s serverless export download

--- a/internal/cli/serverless/export/export.go
+++ b/internal/cli/serverless/export/export.go
@@ -23,7 +23,7 @@ import (
 func Cmd(h *internal.Helper) *cobra.Command {
 	var exportCmd = &cobra.Command{
 		Use:   "export",
-		Short: "Manage serverless cluster exports",
+		Short: "Manage TiDB Serverless exports",
 	}
 
 	exportCmd.AddCommand(CreateCmd(h))

--- a/internal/cli/serverless/export/list.go
+++ b/internal/cli/serverless/export/list.go
@@ -66,7 +66,7 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 
 	var listCmd = &cobra.Command{
 		Use:   "list",
-		Short: "List serverless cluster exports",
+		Short: "List export tasks",
 		Example: fmt.Sprintf(`  List all exports in interactive mode:
   $ %[1]s serverless export list
 

--- a/internal/cli/serverless/list.go
+++ b/internal/cli/serverless/list.go
@@ -46,15 +46,15 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 
 	var listCmd = &cobra.Command{
 		Use:         "list",
-		Short:       "List all serverless clusters",
+		Short:       "List all TiDB Serverless clusters",
 		Annotations: make(map[string]string),
-		Example: fmt.Sprintf(`  List all serverless clusters in interactive mode):
+		Example: fmt.Sprintf(`  List all TiDB Serverless clusters in interactive mode):
   $ %[1]s serverless list
 
-  List all serverless clusters in non-interactive mode:
+  List all TiDB Serverless clusters in non-interactive mode:
   $ %[1]s serverless list -p <project-id>
 
-  List all serverless clusters in non-interactive mode:
+  List all TiDB Serverless clusters in non-interactive mode:
   $ %[1]s serverless list -p <project-id> -o json`, config.CliName),
 		Aliases: []string{"ls"},
 		PreRun: func(cmd *cobra.Command, args []string) {

--- a/internal/cli/serverless/region.go
+++ b/internal/cli/serverless/region.go
@@ -30,9 +30,9 @@ import (
 func RegionCmd(h *internal.Helper) *cobra.Command {
 	var regionCmd = &cobra.Command{
 		Use:         "region",
-		Short:       "List all available regions for serverless clusters",
+		Short:       "List all available regions for TiDB Serverless",
 		Annotations: make(map[string]string),
-		Example: fmt.Sprintf(`  List all available regions for serverless clusters:
+		Example: fmt.Sprintf(`  List all available regions for TiDB Serverless:
   $ %[1]s serverless region`, config.CliName),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			d, err := h.Client()

--- a/internal/cli/serverless/restore.go
+++ b/internal/cli/serverless/restore.go
@@ -73,15 +73,15 @@ func RestoreCmd(h *internal.Helper) *cobra.Command {
 
 	var restoreCmd = &cobra.Command{
 		Use:         "restore",
-		Short:       "Restore a serverless cluster",
+		Short:       "Restore a TiDB Serverless cluster",
 		Annotations: make(map[string]string),
-		Example: fmt.Sprintf(`  Restore a serverless cluster in interactive mode:
+		Example: fmt.Sprintf(`  Restore a TiDB Serverless cluster in interactive mode:
  $ %[1]s serverless restore
 
- Restore a serverless cluster with snaphot mode in non-interactive mode:
+ Restore a TiDB Serverless cluster with snaphot mode in non-interactive mode:
  $ %[1]s serverless restore --backup-id <backup-id>
 
- Restore a serverless cluster with pointInTime mode in non-interactive mode:
+ Restore a TiDB Serverless cluster with pointInTime mode in non-interactive mode:
  $ %[1]s serverless restore -c <cluster-id> --backup-time <backup-time>`, config.CliName),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			err := opts.MarkInteractive(cmd)

--- a/internal/cli/serverless/shell.go
+++ b/internal/cli/serverless/shell.go
@@ -51,13 +51,13 @@ func ShellCmd(h *internal.Helper) *cobra.Command {
 
 	var shellCmd = &cobra.Command{
 		Use:   "shell",
-		Short: "Connect to a serverless cluster",
-		Long: `Connect to a serverless cluster.
+		Short: "Connect to a TiDB Serverless cluster",
+		Long: `Connect to a TiDB Serverless cluster.
 The connection forces the [ANSI SQL mode](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_ansi) for the session.`,
-		Example: fmt.Sprintf(`  Connect to a serverless cluster in interactive mode:
+		Example: fmt.Sprintf(`  Connect to a TiDB Serverless cluster in interactive mode:
   $ %[1]s serverless shell
 
-  Connect to a serverless cluster with default user in non-interactive mode:
+  Connect to a TiDB Serverless cluster with default user in non-interactive mode:
   $ %[1]s serverless shell -c <cluster-id>
 
   Connect to a serverless cluster with default user and password in non-interactive mode:

--- a/internal/cli/serverless/spending_limit.go
+++ b/internal/cli/serverless/spending_limit.go
@@ -58,12 +58,12 @@ func SpendingLimitCmd(h *internal.Helper) *cobra.Command {
 
 	var spendingLimitCmd = &cobra.Command{
 		Use:         "spending-limit",
-		Short:       "Set spending limit for a serverless cluster",
+		Short:       "Set spending limit for a TiDB Serverless cluster",
 		Annotations: make(map[string]string),
-		Example: fmt.Sprintf(`  Set spending limit for serverless clusters in interactive mode:
+		Example: fmt.Sprintf(`  Set spending limit for a TiDB Serverless cluster in interactive mode:
   $ %[1]s serverless spending-limit
 
-  Set spending limit for serverless clusters in non-interactive mode:
+  Set spending limit for a TiDB Serverless cluster in non-interactive mode:
   $ %[1]s serverless spending-limit -c <cluster-id> --monthly <spending-limit-monthly>`, config.CliName),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flags := opts.NonInteractiveFlags()

--- a/internal/cli/serverless/update.go
+++ b/internal/cli/serverless/update.go
@@ -68,15 +68,15 @@ func UpdateCmd(h *internal.Helper) *cobra.Command {
 
 	var updateCmd = &cobra.Command{
 		Use:         "update",
-		Short:       "Update a serverless cluster",
+		Short:       "Update a TiDB Serverless cluster",
 		Annotations: make(map[string]string),
-		Example: fmt.Sprintf(`  Update a serverless cluster in interactive mode:
+		Example: fmt.Sprintf(`  Update a TiDB Serverless cluster in interactive mode:
  $ %[1]s serverless update
 
- Update displayName of serverless cluster in non-interactive mode:
+ Update displayName of a TiDB Serverless cluster in non-interactive mode:
  $ %[1]s serverless update -c <cluster-id> --display-name <new-cluster-mame>
  
- Update labels of serverless cluster in non-interactive mode:
+ Update labels of a TiDB Serverless cluster in non-interactive mode:
  $ %[1]s serverless update -c <cluster-id> --labels "{\"label1\":\"value1\"}"`, config.CliName),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flags := opts.NonInteractiveFlags()


### PR DESCRIPTION
## What is the purpose of the change

<!-- (For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).) -->

## Brief change log

<!-- *(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache* -->
