### PR TITLE
Replace deprecated use

### DIFF
--- a/internal/cli/config/create.go
+++ b/internal/cli/config/create.go
@@ -106,7 +106,7 @@ func CreateCmd(h *internal.Helper) *cobra.Command {
 				}
 
 				p := tea.NewProgram(initialCreationInputModel())
-				inputModel, err := p.StartReturningModel()
+				inputModel, err := p.Run()
 				if err != nil {
 					return errors.Trace(err)
 				}
@@ -181,7 +181,7 @@ func initialCreationInputModel() ui.TextInputModel {
 	var t textinput.Model
 	for i := range m.Inputs {
 		t = textinput.New()
-		t.CursorStyle = config.CursorStyle
+		t.Cursor.Style = config.CursorStyle
 		t.CharLimit = 64
 		f := createConfigField(i)
 

--- a/internal/cli/serverless/branch/create.go
+++ b/internal/cli/serverless/branch/create.go
@@ -235,7 +235,7 @@ func CreateAndSpinnerWait(ctx context.Context, d cloud.TiDBCloudClient, params *
 	}
 
 	p := tea.NewProgram(ui.InitialSpinnerModel(task, "Waiting for branch to be ready"))
-	createModel, err := p.StartReturningModel()
+	createModel, err := p.Run()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -257,7 +257,7 @@ func initialCreateBranchInputModel() ui.TextInputModel {
 
 	for k, v := range createBranchField {
 		t := textinput.New()
-		t.CursorStyle = config.CursorStyle
+		t.Cursor.Style = config.CursorStyle
 		t.CharLimit = 64
 
 		switch k {
@@ -276,7 +276,7 @@ func initialCreateBranchInputModel() ui.TextInputModel {
 
 func GetCreateBranchInput() (tea.Model, error) {
 	p := tea.NewProgram(initialCreateBranchInputModel())
-	inputModel, err := p.StartReturningModel()
+	inputModel, err := p.Run()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/cli/serverless/create.go
+++ b/internal/cli/serverless/create.go
@@ -360,7 +360,7 @@ func CreateAndSpinnerWait(ctx context.Context, d cloud.TiDBCloudClient, v1Cluste
 	}
 
 	p := tea.NewProgram(ui.InitialSpinnerModel(task, "Waiting for cluster to be ready"))
-	createModel, err := p.StartReturningModel()
+	createModel, err := p.Run()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/cli/serverless/dataimport/start/start.go
+++ b/internal/cli/serverless/dataimport/start/start.go
@@ -230,7 +230,7 @@ func spinnerWaitStartOp(ctx context.Context, h *internal.Helper, d cloud.TiDBClo
 	}
 
 	p := tea.NewProgram(ui.InitialSpinnerModel(task, "Starting import task"))
-	model, err := p.StartReturningModel()
+	model, err := p.Run()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/cli/serverless/spending_limit.go
+++ b/internal/cli/serverless/spending_limit.go
@@ -173,16 +173,16 @@ func GetMonthlyInput() (tea.Model, error) {
 		Inputs: make([]textinput.Model, 1),
 	}
 	t := textinput.New()
-	t.CursorStyle = config.CursorStyle
+	t.Cursor.Style = config.CursorStyle
 	t.CharLimit = 64
-	t.Placeholder = "Input monthly spending limit(int)"
+	t.Placeholder = "Input monthly spending limit in USD cents (int)"
 	t.Focus()
 	t.PromptStyle = config.FocusedStyle
 	t.TextStyle = config.FocusedStyle
 	m.Inputs[0] = t
 
 	p := tea.NewProgram(m)
-	inputModel, err := p.StartReturningModel()
+	inputModel, err := p.Run()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/cli/serverless/update.go
+++ b/internal/cli/serverless/update.go
@@ -214,7 +214,7 @@ func GetUpdateClusterInput() (tea.Model, error) {
 		Inputs: make([]textinput.Model, 1),
 	}
 	t := textinput.New()
-	t.CursorStyle = config.CursorStyle
+	t.Cursor.Style = config.CursorStyle
 	t.CharLimit = 64
 	t.Placeholder = "New value"
 	t.Focus()
@@ -223,7 +223,7 @@ func GetUpdateClusterInput() (tea.Model, error) {
 	m.Inputs[0] = t
 
 	p := tea.NewProgram(m)
-	inputModel, err := p.StartReturningModel()
+	inputModel, err := p.Run()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/cli/upgrade/upgrade.go
+++ b/internal/cli/upgrade/upgrade.go
@@ -170,7 +170,7 @@ func updateAndSpinnerWait(ctx context.Context, h *internal.Helper, newRelease *g
 	}
 
 	p := tea.NewProgram(ui.InitialSpinnerModel(task, fmt.Sprintf("Updating the CLI to version %s", newRelease.Version)))
-	model, err := p.StartReturningModel()
+	model, err := p.Run()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/service/cloud/logic.go
+++ b/internal/service/cloud/logic.go
@@ -143,7 +143,7 @@ func GetSelectedProject(pageSize int64, client TiDBCloudClient) (*Project, error
 	model.EnableFilter()
 
 	p := tea.NewProgram(model)
-	projectModel, err := p.StartReturningModel()
+	projectModel, err := p.Run()
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func GetSelectedCluster(projectID string, pageSize int64, client TiDBCloudClient
 	model.EnableFilter()
 
 	p := tea.NewProgram(model)
-	clusterModel, err := p.StartReturningModel()
+	clusterModel, err := p.Run()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -205,7 +205,7 @@ func GetSelectedField(mutableFields []string) (string, error) {
 	model.EnableFilter()
 
 	p := tea.NewProgram(model)
-	fieldModel, err := p.StartReturningModel()
+	fieldModel, err := p.Run()
 	if err != nil {
 		return "", errors.Trace(err)
 	}
@@ -230,7 +230,7 @@ func GetSpendingLimitField(mutableFields []string) (string, error) {
 	model.EnableFilter()
 
 	p := tea.NewProgram(model)
-	fieldModel, err := p.StartReturningModel()
+	fieldModel, err := p.Run()
 	if err != nil {
 		return "", errors.Trace(err)
 	}
@@ -268,7 +268,7 @@ func GetSelectedBranch(clusterID string, pageSize int64, client TiDBCloudClient)
 	model.EnableFilter()
 
 	p := tea.NewProgram(model)
-	bModel, err := p.StartReturningModel()
+	bModel, err := p.Run()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -443,7 +443,7 @@ func GetSelectedImport(ctx context.Context, cID string, pageSize int64, client T
 	model.EnableFilter()
 
 	p := tea.NewProgram(model)
-	importModel, err := p.StartReturningModel()
+	importModel, err := p.Run()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What is the purpose of the change

<!-- (For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).) -->

## Brief change log

<!-- *(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache* -->
