### PR TITLE
Fix select ui npe

### DIFF
--- a/internal/cli/serverless/dataimport/start/start.go
+++ b/internal/cli/serverless/dataimport/start/start.go
@@ -178,8 +178,11 @@ func getSelectedSourceType() (SourceType, error) {
 	if m, _ := SourceTypeModel.(ui.SelectModel); m.Interrupted {
 		return SourceTypeUnknown, util.InterruptError
 	}
-	fileType := SourceTypeModel.(ui.SelectModel).GetSelectedItem().(SourceType)
-	return fileType, nil
+	fileType := SourceTypeModel.(ui.SelectModel).GetSelectedItem()
+	if fileType == nil {
+		return SourceTypeUnknown, errors.New("no source type selected")
+	}
+	return fileType.(SourceType), nil
 }
 
 func waitStartOp(h *internal.Helper, d cloud.TiDBCloudClient, params *importOp.ImportServiceCreateImportParams) error {

--- a/internal/cli/serverless/export/create.go
+++ b/internal/cli/serverless/export/create.go
@@ -319,8 +319,11 @@ func GetSelectedTargetType() (TargetType, error) {
 	if m, _ := targetTypeModel.(ui.SelectModel); m.Interrupted {
 		return TargetTypeUnknown, util.InterruptError
 	}
-	targetType := targetTypeModel.(ui.SelectModel).GetSelectedItem().(TargetType)
-	return targetType, nil
+	targetType := targetTypeModel.(ui.SelectModel).GetSelectedItem()
+	if targetType == nil {
+		return TargetTypeUnknown, errors.New("no export target selected")
+	}
+	return targetType.(TargetType), nil
 }
 
 func GetSelectedFileType() (FileType, error) {
@@ -339,8 +342,11 @@ func GetSelectedFileType() (FileType, error) {
 	if m, _ := fileTypeModel.(ui.SelectModel); m.Interrupted {
 		return FileTypeUnknown, util.InterruptError
 	}
-	fileType := fileTypeModel.(ui.SelectModel).GetSelectedItem().(FileType)
-	return fileType, nil
+	fileType := fileTypeModel.(ui.SelectModel).GetSelectedItem()
+	if fileType == nil {
+		return FileTypeUnknown, errors.New("no export file type selected")
+	}
+	return fileType.(FileType), nil
 }
 
 func GetSelectedCompression() (string, error) {
@@ -359,8 +365,11 @@ func GetSelectedCompression() (string, error) {
 	if m, _ := fileTypeModel.(ui.SelectModel); m.Interrupted {
 		return "", util.InterruptError
 	}
-	compression := fileTypeModel.(ui.SelectModel).GetSelectedItem().(string)
-	return compression, nil
+	compression := fileTypeModel.(ui.SelectModel).GetSelectedItem()
+	if compression == nil {
+		return "", errors.New("no compression algorithm selected")
+	}
+	return compression.(string), nil
 }
 
 func initialS3InputModel() ui.TextInputModel {

--- a/internal/service/cloud/logic.go
+++ b/internal/service/cloud/logic.go
@@ -150,8 +150,11 @@ func GetSelectedProject(pageSize int64, client TiDBCloudClient) (*Project, error
 	if m, _ := projectModel.(ui.SelectModel); m.Interrupted {
 		return nil, util.InterruptError
 	}
-	res := projectModel.(ui.SelectModel).GetSelectedItem().(*Project)
-	return res, nil
+	res := projectModel.(ui.SelectModel).GetSelectedItem()
+	if res == nil {
+		return nil, errors.New("no project selected")
+	}
+	return res.(*Project), nil
 }
 
 func GetSelectedCluster(projectID string, pageSize int64, client TiDBCloudClient) (*Cluster, error) {
@@ -187,8 +190,11 @@ func GetSelectedCluster(projectID string, pageSize int64, client TiDBCloudClient
 	if m, _ := clusterModel.(ui.SelectModel); m.Interrupted {
 		return nil, util.InterruptError
 	}
-	cluster := clusterModel.(ui.SelectModel).GetSelectedItem().(*Cluster)
-	return cluster, nil
+	cluster := clusterModel.(ui.SelectModel).GetSelectedItem()
+	if cluster == nil {
+		return nil, errors.New("no cluster selected")
+	}
+	return cluster.(*Cluster), nil
 }
 
 func GetSelectedField(mutableFields []string) (string, error) {
@@ -212,8 +218,11 @@ func GetSelectedField(mutableFields []string) (string, error) {
 	if m, _ := fieldModel.(ui.SelectModel); m.Interrupted {
 		return "", util.InterruptError
 	}
-	field := fieldModel.(ui.SelectModel).GetSelectedItem().(string)
-	return field, nil
+	field := fieldModel.(ui.SelectModel).GetSelectedItem()
+	if field == nil {
+		return "", errors.New("no field selected")
+	}
+	return field.(string), nil
 }
 
 func GetSpendingLimitField(mutableFields []string) (string, error) {
@@ -237,8 +246,11 @@ func GetSpendingLimitField(mutableFields []string) (string, error) {
 	if m, _ := fieldModel.(ui.SelectModel); m.Interrupted {
 		return "", util.InterruptError
 	}
-	field := fieldModel.(ui.SelectModel).GetSelectedItem().(string)
-	return field, nil
+	field := fieldModel.(ui.SelectModel).GetSelectedItem()
+	if field == nil {
+		return "", errors.New("no type selected")
+	}
+	return field.(string), nil
 }
 
 func GetSelectedBranch(clusterID string, pageSize int64, client TiDBCloudClient) (*Branch, error) {
@@ -275,8 +287,11 @@ func GetSelectedBranch(clusterID string, pageSize int64, client TiDBCloudClient)
 	if m, _ := bModel.(ui.SelectModel); m.Interrupted {
 		return nil, util.InterruptError
 	}
-	branch := bModel.(ui.SelectModel).GetSelectedItem().(*Branch)
-	return branch, nil
+	branch := bModel.(ui.SelectModel).GetSelectedItem()
+	if branch == nil {
+		return nil, errors.New("no branch selected")
+	}
+	return branch.(*Branch), nil
 }
 
 func GetSelectedExport(clusterID string, pageSize int64, client TiDBCloudClient) (*Export, error) {
@@ -311,8 +326,11 @@ func GetSelectedExport(clusterID string, pageSize int64, client TiDBCloudClient)
 	if m, _ := eModel.(ui.SelectModel); m.Interrupted {
 		return nil, util.InterruptError
 	}
-	export := eModel.(ui.SelectModel).GetSelectedItem().(*Export)
-	return export, nil
+	export := eModel.(ui.SelectModel).GetSelectedItem()
+	if export == nil {
+		return nil, errors.New("no export selected")
+	}
+	return export.(*Export), nil
 }
 
 func GetSelectedLocalExport(clusterID string, pageSize int64, client TiDBCloudClient) (*Export, error) {
@@ -349,8 +367,11 @@ func GetSelectedLocalExport(clusterID string, pageSize int64, client TiDBCloudCl
 	if m, _ := eModel.(ui.SelectModel); m.Interrupted {
 		return nil, util.InterruptError
 	}
-	export := eModel.(ui.SelectModel).GetSelectedItem().(*Export)
-	return export, nil
+	export := eModel.(ui.SelectModel).GetSelectedItem()
+	if export == nil {
+		return nil, errors.New("no export selected")
+	}
+	return export.(*Export), nil
 }
 
 func GetSelectedServerlessBackup(clusterID string, pageSize int32, client TiDBCloudClient) (*ServerlessBackup, error) {
@@ -387,8 +408,11 @@ func GetSelectedServerlessBackup(clusterID string, pageSize int32, client TiDBCl
 	if m, _ := bModel.(ui.SelectModel); m.Interrupted {
 		return nil, util.InterruptError
 	}
-	backup := bModel.(ui.SelectModel).GetSelectedItem().(*ServerlessBackup)
-	return backup, nil
+	backup := bModel.(ui.SelectModel).GetSelectedItem()
+	if backup == nil {
+		return nil, errors.New("no backup selected")
+	}
+	return backup.(*ServerlessBackup), nil
 }
 
 func GetSelectedRestoreMode() (string, error) {
@@ -411,8 +435,11 @@ func GetSelectedRestoreMode() (string, error) {
 	if m, _ := bModel.(ui.SelectModel); m.Interrupted {
 		return "", util.InterruptError
 	}
-	restoreMode := bModel.(ui.SelectModel).GetSelectedItem().(string)
-	return restoreMode, nil
+	restoreMode := bModel.(ui.SelectModel).GetSelectedItem()
+	if restoreMode == nil {
+		return "", errors.New("no restore mode selected")
+	}
+	return restoreMode.(string), nil
 }
 
 // GetSelectedImport get the selected import task. statusFilter is used to filter the available options, only imports has status in statusFilter will be available.
@@ -450,8 +477,11 @@ func GetSelectedImport(ctx context.Context, cID string, pageSize int64, client T
 	if m, _ := importModel.(ui.SelectModel); m.Interrupted {
 		return nil, util.InterruptError
 	}
-	res := importModel.(ui.SelectModel).GetSelectedItem().(*Import)
-	return res, nil
+	res := importModel.(ui.SelectModel).GetSelectedItem()
+	if res == nil {
+		return nil, errors.New("no import task selected")
+	}
+	return res.(*Import), nil
 }
 
 func RetrieveProjects(pageSize int64, d TiDBCloudClient) (int64, []*iamModel.APIProject, error) {

--- a/internal/ui/select_model.go
+++ b/internal/ui/select_model.go
@@ -237,6 +237,9 @@ func (m SelectModel) View() string {
 
 	// Has user selected?
 	if m.Selected != -1 {
+		if len(m.VisibleChoices) == 0 {
+			return s
+		}
 		checked := "x" // selected!
 		cursor := ">"
 		s += fmt.Sprintf("%s [%s] %s\n", cursor, checked, m.VisibleChoices[m.Selected])
@@ -280,6 +283,9 @@ func (m SelectModel) View() string {
 
 // GetSelectedItem returns the selected item in VisibleChoices.
 func (m SelectModel) GetSelectedItem() interface{} {
+	if len(m.VisibleChoices) == 0 || m.Selected == -1 {
+		return nil
+	}
 	return m.VisibleChoices[m.Selected]
 }
 


### PR DESCRIPTION
## What is the purpose of the change

<!-- (For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).) -->

## Brief change log

<!-- *(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache* -->
