### PR TITLE
warn user when auth login and there is already an API key in profile

### DIFF
--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -105,6 +105,11 @@ func LoginCmd(h *internal.Helper) *cobra.Command {
 			}
 
 			color.HiGreen("\nSuccessfully logged in.")
+
+			if config.GetPublicKey() != "" && config.GetPrivateKey() != "" {
+				color.HiYellow("\nDetect an API key already set in %s profile! Note it will take precedence over auth token.", config.ActiveProfileName())
+			}
+
 			return nil
 		},
 	}


### PR DESCRIPTION
## What is the purpose of the change

<!-- (For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).) -->

## Brief change log

<!-- *(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache* -->
