### PR TITLE
Fix Ctrl-C can't cancel ongoing http request

### DIFF
--- a/internal/cli/ai/ai.go
+++ b/internal/cli/ai/ai.go
@@ -94,6 +94,7 @@ func AICmd(h *internal.Helper) *cobra.Command {
 			}
 			param := operations.NewChatParams()
 
+			context := cmd.Context()
 			if opts.interactive {
 				task := func(messages []ui.ChatMessage) tea.Msg {
 					msgs := make([]*models.PingchatChatMessage, 0, len(messages))
@@ -114,7 +115,7 @@ func AICmd(h *internal.Helper) *cobra.Command {
 					chat, err := client.Chat(param.WithChatInfo(&models.PingchatChatInfo{
 						Messages: msgs,
 						Domain:   domain,
-					}))
+					}).WithContext(context))
 
 					if err != nil {
 						return ui.EndSendingMsg{
@@ -168,7 +169,7 @@ func AICmd(h *internal.Helper) *cobra.Command {
 						},
 					},
 					Domain: domain,
-				}))
+				}).WithContext(context))
 
 				if err != nil {
 					return err

--- a/internal/cli/project/list.go
+++ b/internal/cli/project/list.go
@@ -45,7 +45,7 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			_, items, err := cloud.RetrieveProjects(h.QueryPageSize, d)
+			_, items, err := cloud.RetrieveProjects(cmd.Context(), h.QueryPageSize, d)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/project/list_test.go
+++ b/internal/cli/project/list_test.go
@@ -16,6 +16,7 @@ package project
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"testing"
@@ -106,6 +107,7 @@ func (suite *ListProjectSuite) SetupTest() {
 
 func (suite *ListProjectSuite) TestListProjectArgs() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
 
 	body := &iamModel.APIListProjectsRsp{}
 	err := json.Unmarshal([]byte(resultStr), body)
@@ -114,7 +116,7 @@ func (suite *ListProjectSuite) TestListProjectArgs() {
 		Payload: body,
 	}
 	suite.mockClient.On("ListProjects", iamApi.NewGetV1beta1ProjectsParams().
-		WithPageSize(&suite.h.QueryPageSize)).Return(result, nil)
+		WithPageSize(&suite.h.QueryPageSize).WithContext(ctx)).Return(result, nil)
 
 	tests := []struct {
 		name         string
@@ -143,6 +145,7 @@ func (suite *ListProjectSuite) TestListProjectArgs() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			cmd := ListCmd(suite.h)
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)
@@ -160,6 +163,7 @@ func (suite *ListProjectSuite) TestListProjectArgs() {
 
 func (suite *ListProjectSuite) TestListProjectWithMultiPages() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
 	suite.h.QueryPageSize = 1
 	nextPageToken := "next_token"
 
@@ -176,9 +180,9 @@ func (suite *ListProjectSuite) TestListProjectWithMultiPages() {
 		Payload: body2,
 	}
 	suite.mockClient.On("ListProjects", iamApi.NewGetV1beta1ProjectsParams().
-		WithPageSize(&suite.h.QueryPageSize)).Return(resultPageOne, nil)
+		WithPageSize(&suite.h.QueryPageSize).WithContext(ctx)).Return(resultPageOne, nil)
 	suite.mockClient.On("ListProjects", iamApi.NewGetV1beta1ProjectsParams().
-		WithPageSize(&suite.h.QueryPageSize).WithPageToken(&nextPageToken)).Return(resultPageTwo, nil)
+		WithPageSize(&suite.h.QueryPageSize).WithPageToken(&nextPageToken).WithContext(ctx)).Return(resultPageTwo, nil)
 	tests := []struct {
 		name         string
 		args         []string
@@ -194,6 +198,7 @@ func (suite *ListProjectSuite) TestListProjectWithMultiPages() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			cmd := ListCmd(suite.h)
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"tidbcloud-cli/internal"
@@ -241,8 +242,8 @@ func initConfig() {
 	// Find home directory.
 	home, err := os.UserHomeDir()
 	cobra.CheckErr(err)
-	path := home + "/" + config.HomePath
-	err = os.MkdirAll(path+"/cache", 0700)
+	path := filepath.Join(home, config.HomePath)
+	err = os.MkdirAll(path, 0700)
 	if err != nil {
 		color.Red("Failed to create home directory: %s", err)
 		os.Exit(1)

--- a/internal/cli/serverless/backup/delete.go
+++ b/internal/cli/serverless/backup/delete.go
@@ -92,6 +92,7 @@ func DeleteCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ctx := cmd.Context()
 
 			var backupID string
 			if opts.interactive {
@@ -100,15 +101,15 @@ func DeleteCmd(h *internal.Helper) *cobra.Command {
 				}
 
 				// interactive mode
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
-				cluster, err := cloud.GetSelectedCluster(project.ID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, project.ID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
-				backup, err := cloud.GetSelectedServerlessBackup(cluster.ID, int32(h.QueryPageSize), d)
+				backup, err := cloud.GetSelectedServerlessBackup(ctx, cluster.ID, int32(h.QueryPageSize), d)
 				if err != nil {
 					return err
 				}
@@ -147,7 +148,7 @@ func DeleteCmd(h *internal.Helper) *cobra.Command {
 				}
 			}
 
-			params := brApi.NewBackupRestoreServiceDeleteBackupParams().WithBackupID(backupID)
+			params := brApi.NewBackupRestoreServiceDeleteBackupParams().WithBackupID(backupID).WithContext(ctx)
 			_, err = d.DeleteBackup(params)
 			if err != nil {
 				return errors.Trace(err)

--- a/internal/cli/serverless/backup/delete_test.go
+++ b/internal/cli/serverless/backup/delete_test.go
@@ -16,6 +16,7 @@ package backup
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -53,10 +54,11 @@ func (suite *DeleteBackupSuite) SetupTest() {
 
 func (suite *DeleteBackupSuite) TestDeleteBackup() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
 
 	backupID := "289048"
 	suite.mockClient.On("DeleteBackup", brApi.NewBackupRestoreServiceDeleteBackupParams().
-		WithBackupID(backupID)).
+		WithBackupID(backupID).WithContext(ctx)).
 		Return(&brApi.BackupRestoreServiceDeleteBackupOK{}, nil)
 
 	tests := []struct {
@@ -81,6 +83,7 @@ func (suite *DeleteBackupSuite) TestDeleteBackup() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			cmd := DeleteCmd(suite.h)
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)

--- a/internal/cli/serverless/backup/describe.go
+++ b/internal/cli/serverless/backup/describe.go
@@ -16,6 +16,7 @@ package backup
 
 import (
 	"fmt"
+
 	"tidbcloud-cli/internal/output"
 
 	"tidbcloud-cli/internal"
@@ -87,6 +88,7 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ctx := cmd.Context()
 
 			var backupID string
 			var clusterID string
@@ -96,17 +98,17 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 				}
 
 				// interactive mode
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
-				cluster, err := cloud.GetSelectedCluster(project.ID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, project.ID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
 				clusterID = cluster.ID
 
-				backup, err := cloud.GetSelectedServerlessBackup(clusterID, int32(h.QueryPageSize), d)
+				backup, err := cloud.GetSelectedServerlessBackup(ctx, clusterID, int32(h.QueryPageSize), d)
 				if err != nil {
 					return err
 				}
@@ -119,7 +121,7 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 				}
 			}
 
-			params := brAPI.NewBackupRestoreServiceGetBackupParams().WithBackupID(backupID)
+			params := brAPI.NewBackupRestoreServiceGetBackupParams().WithBackupID(backupID).WithContext(ctx)
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/internal/cli/serverless/backup/describe_test.go
+++ b/internal/cli/serverless/backup/describe_test.go
@@ -16,6 +16,7 @@ package backup
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -63,6 +64,7 @@ func (suite *DescribeBackupSuite) SetupTest() {
 
 func (suite *DescribeBackupSuite) TestDescribeBackup() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
 
 	body := &brModel.V1beta1Backup{}
 	err := json.Unmarshal([]byte(getBackupResult), body)
@@ -73,7 +75,7 @@ func (suite *DescribeBackupSuite) TestDescribeBackup() {
 	backupId := "289048"
 
 	suite.mockClient.On("GetBackup", brApi.NewBackupRestoreServiceGetBackupParams().
-		WithBackupID(backupId)).
+		WithBackupID(backupId).WithContext(ctx)).
 		Return(result, nil)
 
 	tests := []struct {
@@ -98,6 +100,7 @@ func (suite *DescribeBackupSuite) TestDescribeBackup() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			cmd := DescribeCmd(suite.h)
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)

--- a/internal/cli/serverless/backup/list.go
+++ b/internal/cli/serverless/backup/list.go
@@ -88,6 +88,7 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ctx := cmd.Context()
 
 			var clusterID string
 			if opts.interactive {
@@ -95,11 +96,11 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 					return errors.New("The terminal doesn't support interactive mode, please use non-interactive mode")
 				}
 
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
-				cluster, err := cloud.GetSelectedCluster(project.ID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, project.ID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
@@ -111,7 +112,7 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 				}
 			}
 
-			total, items, err := cloud.RetrieveServerlessBackups(clusterID, int32(h.QueryPageSize), d)
+			total, items, err := cloud.RetrieveServerlessBackups(ctx, clusterID, int32(h.QueryPageSize), d)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/serverless/branch/create_test.go
+++ b/internal/cli/serverless/branch/create_test.go
@@ -16,6 +16,7 @@ package branch
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -56,6 +57,7 @@ func (suite *CreateBranchSuite) SetupTest() {
 
 func (suite *CreateBranchSuite) TestCreateBranchArgs() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
 
 	clusterID := "12345"
 	branchName := "test"
@@ -65,7 +67,7 @@ func (suite *CreateBranchSuite) TestCreateBranchArgs() {
 		DisplayName: &branchName,
 	}
 	suite.mockClient.On("CreateBranch", branchApi.NewBranchServiceCreateBranchParams().
-		WithClusterID(clusterID).WithBranch(createBranchBody)).
+		WithClusterID(clusterID).WithBranch(createBranchBody).WithContext(ctx)).
 		Return(&branchApi.BranchServiceCreateBranchOK{
 			Payload: &branchModel.V1beta1Branch{
 				BranchID: branchId,
@@ -79,7 +81,7 @@ func (suite *CreateBranchSuite) TestCreateBranchArgs() {
 		Payload: body,
 	}
 	suite.mockClient.On("GetBranch", branchApi.NewBranchServiceGetBranchParams().
-		WithClusterID(clusterID).WithBranchID(branchId)).
+		WithClusterID(clusterID).WithBranchID(branchId).WithContext(ctx)).
 		Return(result, nil)
 
 	tests := []struct {
@@ -109,6 +111,7 @@ func (suite *CreateBranchSuite) TestCreateBranchArgs() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			cmd := CreateCmd(suite.h)
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)

--- a/internal/cli/serverless/branch/delete.go
+++ b/internal/cli/serverless/branch/delete.go
@@ -16,6 +16,7 @@ package branch
 
 import (
 	"fmt"
+
 	"tidbcloud-cli/internal"
 	"tidbcloud-cli/internal/config"
 	"tidbcloud-cli/internal/flag"
@@ -92,6 +93,7 @@ func DeleteCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ctx := cmd.Context()
 
 			var clusterID string
 			var branchID string
@@ -101,17 +103,17 @@ func DeleteCmd(h *internal.Helper) *cobra.Command {
 				}
 
 				// interactive mode
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
-				cluster, err := cloud.GetSelectedCluster(project.ID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, project.ID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
 				clusterID = cluster.ID
 
-				branch, err := cloud.GetSelectedBranch(clusterID, h.QueryPageSize, d)
+				branch, err := cloud.GetSelectedBranch(ctx, clusterID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
@@ -158,7 +160,7 @@ func DeleteCmd(h *internal.Helper) *cobra.Command {
 			}
 
 			params := branchApi.NewBranchServiceDeleteBranchParams().
-				WithClusterID(clusterID).WithBranchID(branchID)
+				WithClusterID(clusterID).WithBranchID(branchID).WithContext(ctx)
 			_, err = d.DeleteBranch(params)
 			if err != nil {
 				return errors.Trace(err)

--- a/internal/cli/serverless/branch/delete_test.go
+++ b/internal/cli/serverless/branch/delete_test.go
@@ -16,6 +16,7 @@ package branch
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -54,11 +55,12 @@ func (suite *DeleteBranchSuite) SetupTest() {
 
 func (suite *DeleteBranchSuite) TestDeleteBranchArgs() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
 
 	clusterID := "12345"
 	branchID := "12345"
 	suite.mockClient.On("DeleteBranch", branchApi.NewBranchServiceDeleteBranchParams().
-		WithBranchID(branchID).WithClusterID(clusterID)).
+		WithBranchID(branchID).WithClusterID(clusterID).WithContext(ctx)).
 		Return(&branchApi.BranchServiceDeleteBranchOK{}, nil)
 
 	tests := []struct {
@@ -93,6 +95,7 @@ func (suite *DeleteBranchSuite) TestDeleteBranchArgs() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			cmd := DeleteCmd(suite.h)
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)

--- a/internal/cli/serverless/branch/describe.go
+++ b/internal/cli/serverless/branch/describe.go
@@ -126,7 +126,7 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 			}
 
 			params := branchApi.NewBranchServiceGetBranchParams().
-				WithClusterID(clusterID).WithBranchID(branchID)
+				WithClusterID(clusterID).WithBranchID(branchID).WithContext(ctx)
 			branch, err := d.GetBranch(params)
 			if err != nil {
 				return errors.Trace(err)

--- a/internal/cli/serverless/branch/describe.go
+++ b/internal/cli/serverless/branch/describe.go
@@ -87,6 +87,7 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ctx := cmd.Context()
 
 			var branchID string
 			var clusterID string
@@ -96,17 +97,17 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 				}
 
 				// interactive mode
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
-				cluster, err := cloud.GetSelectedCluster(project.ID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, project.ID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
 				clusterID = cluster.ID
 
-				branch, err := cloud.GetSelectedBranch(clusterID, h.QueryPageSize, d)
+				branch, err := cloud.GetSelectedBranch(ctx, clusterID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}

--- a/internal/cli/serverless/branch/describe_test.go
+++ b/internal/cli/serverless/branch/describe_test.go
@@ -16,6 +16,7 @@ package branch
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -83,6 +84,7 @@ func (suite *DescribeBranchSuite) SetupTest() {
 
 func (suite *DescribeBranchSuite) TestDescribeBranchArgs() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
 
 	body := &branchModel.V1beta1Branch{}
 	err := json.Unmarshal([]byte(getBranchResultStr), body)
@@ -93,7 +95,7 @@ func (suite *DescribeBranchSuite) TestDescribeBranchArgs() {
 	clusterID := "10202848322613926203"
 	branchID := "bran-fgwdnpasmrahnh5iozqawnmijq"
 	suite.mockClient.On("GetBranch", branchApi.NewBranchServiceGetBranchParams().
-		WithBranchID(branchID).WithClusterID(clusterID)).
+		WithBranchID(branchID).WithClusterID(clusterID).WithContext(ctx)).
 		Return(result, nil)
 
 	tests := []struct {
@@ -123,6 +125,7 @@ func (suite *DescribeBranchSuite) TestDescribeBranchArgs() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			cmd := DescribeCmd(suite.h)
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)

--- a/internal/cli/serverless/branch/list.go
+++ b/internal/cli/serverless/branch/list.go
@@ -88,6 +88,7 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ctx := cmd.Context()
 
 			var clusterID string
 			if opts.interactive {
@@ -95,11 +96,11 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 					return errors.New("The terminal doesn't support interactive mode, please use non-interactive mode")
 				}
 
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
-				cluster, err := cloud.GetSelectedCluster(project.ID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, project.ID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
@@ -111,7 +112,7 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 				}
 			}
 
-			total, items, err := cloud.RetrieveBranches(clusterID, h.QueryPageSize, d)
+			total, items, err := cloud.RetrieveBranches(ctx, clusterID, h.QueryPageSize, d)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/serverless/branch/list_test.go
+++ b/internal/cli/serverless/branch/list_test.go
@@ -16,6 +16,7 @@ package branch
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"strings"
@@ -104,6 +105,7 @@ func (suite *ListBranchSuite) SetupTest() {
 func (suite *ListBranchSuite) TestListBranchesArgs() {
 	assert := require.New(suite.T())
 	pageSize := int32(suite.h.QueryPageSize)
+	ctx := context.Background()
 
 	body := &branchModel.V1beta1ListBranchesResponse{}
 	err := json.Unmarshal([]byte(listResultStr), body)
@@ -113,7 +115,7 @@ func (suite *ListBranchSuite) TestListBranchesArgs() {
 	}
 	clusterID := "12345"
 	suite.mockClient.On("ListBranches", branchApi.NewBranchServiceListBranchesParams().
-		WithClusterID(clusterID).WithPageSize(&pageSize)).
+		WithClusterID(clusterID).WithPageSize(&pageSize).WithContext(ctx)).
 		Return(result, nil)
 
 	tests := []struct {
@@ -143,6 +145,7 @@ func (suite *ListBranchSuite) TestListBranchesArgs() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			cmd := ListCmd(suite.h)
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)
@@ -160,6 +163,7 @@ func (suite *ListBranchSuite) TestListBranchesArgs() {
 
 func (suite *ListBranchSuite) TestListBranchesWithMultiPages() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
 	pageSize := int32(suite.h.QueryPageSize)
 	pageToken := "2"
 	body := &branchModel.V1beta1ListBranchesResponse{}
@@ -172,7 +176,7 @@ func (suite *ListBranchSuite) TestListBranchesWithMultiPages() {
 
 	clusterID := "12345"
 	suite.mockClient.On("ListBranches", branchApi.NewBranchServiceListBranchesParams().
-		WithClusterID(clusterID).WithPageSize(&pageSize)).
+		WithClusterID(clusterID).WithPageSize(&pageSize).WithContext(ctx)).
 		Return(result, nil)
 
 	body2 := &branchModel.V1beta1ListBranchesResponse{}
@@ -182,7 +186,7 @@ func (suite *ListBranchSuite) TestListBranchesWithMultiPages() {
 		Payload: body2,
 	}
 	suite.mockClient.On("ListBranches", branchApi.NewBranchServiceListBranchesParams().
-		WithClusterID(clusterID).WithPageToken(&pageToken).WithPageSize(&pageSize)).
+		WithClusterID(clusterID).WithPageToken(&pageToken).WithPageSize(&pageSize).WithContext(ctx)).
 		Return(result2, nil)
 	cmd := ListCmd(suite.h)
 
@@ -201,6 +205,7 @@ func (suite *ListBranchSuite) TestListBranchesWithMultiPages() {
 
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)

--- a/internal/cli/serverless/branch/shell.go
+++ b/internal/cli/serverless/branch/shell.go
@@ -189,7 +189,7 @@ The connection forces the [ANSI SQL mode](https://dev.mysql.com/doc/refman/8.0/e
 			}
 
 			var host, name, port string
-			params := branchApi.NewBranchServiceGetBranchParams().WithClusterID(clusterID).WithBranchID(branchID)
+			params := branchApi.NewBranchServiceGetBranchParams().WithClusterID(clusterID).WithBranchID(branchID).WithContext(ctx)
 			branchInfo, err := d.GetBranch(params)
 			if err != nil {
 				return errors.Trace(err)

--- a/internal/cli/serverless/branch/shell.go
+++ b/internal/cli/serverless/branch/shell.go
@@ -110,19 +110,19 @@ The connection forces the [ANSI SQL mode](https://dev.mysql.com/doc/refman/8.0/e
 			var pass *string
 			if opts.interactive {
 				// interactive mode
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
 				projectID := project.ID
 
-				cluster, err := cloud.GetSelectedCluster(projectID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, projectID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
 				clusterID = cluster.ID
 
-				branch, err := cloud.GetSelectedBranch(clusterID, h.QueryPageSize, d)
+				branch, err := cloud.GetSelectedBranch(ctx, clusterID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}

--- a/internal/cli/serverless/create_test.go
+++ b/internal/cli/serverless/create_test.go
@@ -16,6 +16,7 @@ package serverless
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"testing"
@@ -55,6 +56,7 @@ func (suite *CreateClusterSuite) SetupTest() {
 
 func (suite *CreateClusterSuite) TestCreateClusterArgs() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
 
 	projectID := "12345"
 	clusterID := "12345"
@@ -76,14 +78,14 @@ func (suite *CreateClusterSuite) TestCreateClusterArgs() {
 	}
 
 	suite.mockClient.On("CreateCluster", serverlessApi.NewServerlessServiceCreateClusterParams().
-		WithCluster(v1Cluster)).
+		WithCluster(v1Cluster).WithContext(ctx)).
 		Return(&serverlessApi.ServerlessServiceCreateClusterOK{
 			Payload: &serverlessModel.TidbCloudOpenApiserverlessv1beta1Cluster{
 				ClusterID: clusterID,
 			},
 		}, nil)
 	suite.mockClient.On("GetCluster", serverlessApi.NewServerlessServiceGetClusterParams().
-		WithClusterID(clusterID)).
+		WithClusterID(clusterID).WithContext(ctx)).
 		Return(res, nil)
 
 	tests := []struct {
@@ -108,6 +110,7 @@ func (suite *CreateClusterSuite) TestCreateClusterArgs() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			cmd := CreateCmd(suite.h)
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)
@@ -125,6 +128,7 @@ func (suite *CreateClusterSuite) TestCreateClusterArgs() {
 
 func (suite *CreateClusterSuite) TestCreateClusterWithoutProject() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
 
 	clusterID := "12345"
 	clusterName := "test"
@@ -145,14 +149,14 @@ func (suite *CreateClusterSuite) TestCreateClusterWithoutProject() {
 	}
 
 	suite.mockClient.On("CreateCluster", serverlessApi.NewServerlessServiceCreateClusterParams().
-		WithCluster(v1ClusterWithoutProject)).
+		WithCluster(v1ClusterWithoutProject).WithContext(ctx)).
 		Return(&serverlessApi.ServerlessServiceCreateClusterOK{
 			Payload: &serverlessModel.TidbCloudOpenApiserverlessv1beta1Cluster{
 				ClusterID: clusterID,
 			},
 		}, nil)
 	suite.mockClient.On("GetCluster", serverlessApi.NewServerlessServiceGetClusterParams().
-		WithClusterID(clusterID)).
+		WithClusterID(clusterID).WithContext(ctx)).
 		Return(res, nil)
 
 	tests := []struct {
@@ -172,6 +176,7 @@ func (suite *CreateClusterSuite) TestCreateClusterWithoutProject() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			cmd := CreateCmd(suite.h)
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)

--- a/internal/cli/serverless/dataimport/cancel.go
+++ b/internal/cli/serverless/dataimport/cancel.go
@@ -87,6 +87,7 @@ func CancelCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ctx := cmd.Context()
 
 			if opts.interactive {
 				cmd.Annotations[telemetry.InteractiveMode] = "true"
@@ -95,19 +96,19 @@ func CancelCmd(h *internal.Helper) *cobra.Command {
 				}
 
 				// interactive mode
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
 
-				cluster, err := cloud.GetSelectedCluster(project.ID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, project.ID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
 				clusterID = cluster.ID
 
 				// Only task status is pending or importing can be canceled.
-				selectedImport, err := cloud.GetSelectedImport(cmd.Context(), clusterID, h.QueryPageSize, d, []importModel.V1beta1ImportState{
+				selectedImport, err := cloud.GetSelectedImport(ctx, clusterID, h.QueryPageSize, d, []importModel.V1beta1ImportState{
 					importModel.V1beta1ImportStatePREPARING,
 					importModel.V1beta1ImportStateIMPORTING,
 				})

--- a/internal/cli/serverless/dataimport/describe.go
+++ b/internal/cli/serverless/dataimport/describe.go
@@ -84,6 +84,7 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ctx := cmd.Context()
 
 			if opts.interactive {
 				cmd.Annotations[telemetry.InteractiveMode] = "true"
@@ -92,18 +93,18 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 				}
 
 				// interactive mode
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
 
-				cluster, err := cloud.GetSelectedCluster(project.ID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, project.ID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
 				clusterID = cluster.ID
 
-				selectedImport, err := cloud.GetSelectedImport(cmd.Context(), clusterID, h.QueryPageSize, d, []importModel.V1beta1ImportState{})
+				selectedImport, err := cloud.GetSelectedImport(ctx, clusterID, h.QueryPageSize, d, []importModel.V1beta1ImportState{})
 				if err != nil {
 					return err
 				}

--- a/internal/cli/serverless/dataimport/list.go
+++ b/internal/cli/serverless/dataimport/list.go
@@ -87,6 +87,7 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ctx := cmd.Context()
 
 			if opts.interactive {
 				cmd.Annotations[telemetry.InteractiveMode] = "true"
@@ -96,12 +97,12 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 				}
 
 				// interactive mode
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
 
-				cluster, err := cloud.GetSelectedCluster(project.ID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, project.ID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}

--- a/internal/cli/serverless/dataimport/start/local.go
+++ b/internal/cli/serverless/dataimport/start/local.go
@@ -81,12 +81,12 @@ func (o LocalOpts) Run(cmd *cobra.Command) error {
 		}
 
 		// interactive mode
-		project, err := cloud.GetSelectedProject(o.h.QueryPageSize, d)
+		project, err := cloud.GetSelectedProject(ctx, o.h.QueryPageSize, d)
 		if err != nil {
 			return err
 		}
 
-		cluster, err := cloud.GetSelectedCluster(project.ID, o.h.QueryPageSize, d)
+		cluster, err := cloud.GetSelectedCluster(ctx, project.ID, o.h.QueryPageSize, d)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/serverless/delete.go
+++ b/internal/cli/serverless/delete.go
@@ -86,6 +86,7 @@ func DeleteCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ctx := cmd.Context()
 
 			var clusterID string
 			if opts.interactive {
@@ -95,13 +96,13 @@ func DeleteCmd(h *internal.Helper) *cobra.Command {
 				}
 
 				// interactive mode
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
 				projectID := project.ID
 
-				cluster, err := cloud.GetSelectedCluster(projectID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, projectID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
@@ -141,7 +142,7 @@ func DeleteCmd(h *internal.Helper) *cobra.Command {
 				}
 			}
 
-			params := serverlessApi.NewServerlessServiceDeleteClusterParams().WithClusterID(clusterID)
+			params := serverlessApi.NewServerlessServiceDeleteClusterParams().WithClusterID(clusterID).WithContext(cmd.Context())
 			cluster, err := d.DeleteCluster(params)
 			if err != nil {
 				return errors.Trace(err)

--- a/internal/cli/serverless/delete_test.go
+++ b/internal/cli/serverless/delete_test.go
@@ -16,6 +16,7 @@ package serverless
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -55,11 +56,12 @@ func (suite *DeleteClusterSuite) SetupTest() {
 
 func (suite *DeleteClusterSuite) TestDeleteClusterArgs() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
 
 	clusterID := "12345"
 	state := "DELETING"
 	suite.mockClient.On("DeleteCluster", serverlessApi.NewServerlessServiceDeleteClusterParams().
-		WithClusterID(clusterID)).
+		WithClusterID(clusterID).WithContext(ctx)).
 		Return(&serverlessApi.ServerlessServiceDeleteClusterOK{
 			Payload: &serverlessModel.TidbCloudOpenApiserverlessv1beta1Cluster{
 				State: (*serverlessModel.Commonv1beta1ClusterState)(&state),
@@ -93,6 +95,7 @@ func (suite *DeleteClusterSuite) TestDeleteClusterArgs() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			cmd := DeleteCmd(suite.h)
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)

--- a/internal/cli/serverless/describe.go
+++ b/internal/cli/serverless/describe.go
@@ -80,6 +80,7 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ctx := cmd.Context()
 
 			var clusterID string
 			if opts.interactive {
@@ -89,13 +90,13 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 				}
 
 				// interactive mode
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
 				projectID := project.ID
 
-				cluster, err := cloud.GetSelectedCluster(projectID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, projectID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
@@ -109,7 +110,7 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 				clusterID = cID
 			}
 
-			params := serverlessApi.NewServerlessServiceGetClusterParams().WithClusterID(clusterID)
+			params := serverlessApi.NewServerlessServiceGetClusterParams().WithClusterID(clusterID).WithContext(cmd.Context())
 
 			cluster, err := d.GetCluster(params)
 			if err != nil {

--- a/internal/cli/serverless/describe_test.go
+++ b/internal/cli/serverless/describe_test.go
@@ -16,6 +16,7 @@ package serverless
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"testing"
@@ -104,6 +105,7 @@ func (suite *DescribeClusterSuite) SetupTest() {
 
 func (suite *DescribeClusterSuite) TestDescribeClusterArgs() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
 
 	body := &serverlessModel.TidbCloudOpenApiserverlessv1beta1Cluster{}
 	err := json.Unmarshal([]byte(getClusterResultStr), body)
@@ -113,7 +115,7 @@ func (suite *DescribeClusterSuite) TestDescribeClusterArgs() {
 	}
 	clusterID := "12345"
 	suite.mockClient.On("GetCluster", serverlessApi.NewServerlessServiceGetClusterParams().
-		WithClusterID(clusterID)).
+		WithClusterID(clusterID).WithContext(ctx)).
 		Return(result, nil)
 
 	tests := []struct {
@@ -138,6 +140,7 @@ func (suite *DescribeClusterSuite) TestDescribeClusterArgs() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			cmd := DescribeCmd(suite.h)
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)

--- a/internal/cli/serverless/export/cancel.go
+++ b/internal/cli/serverless/export/cancel.go
@@ -88,6 +88,7 @@ func CancelCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ctx := cmd.Context()
 
 			var clusterID string
 			var exportID string
@@ -97,17 +98,17 @@ func CancelCmd(h *internal.Helper) *cobra.Command {
 				}
 
 				// interactive mode
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
-				cluster, err := cloud.GetSelectedCluster(project.ID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, project.ID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
 				clusterID = cluster.ID
 
-				export, err := cloud.GetSelectedExport(clusterID, h.QueryPageSize, d)
+				export, err := cloud.GetSelectedExport(ctx, clusterID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
@@ -152,7 +153,7 @@ func CancelCmd(h *internal.Helper) *cobra.Command {
 			}
 
 			params := exportApi.NewExportServiceCancelExportParams().
-				WithClusterID(clusterID).WithExportID(exportID)
+				WithClusterID(clusterID).WithExportID(exportID).WithContext(ctx)
 			_, err = d.CancelExport(params)
 			if err != nil {
 				return errors.Trace(err)

--- a/internal/cli/serverless/export/create.go
+++ b/internal/cli/serverless/export/create.go
@@ -131,6 +131,7 @@ func CreateCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ctx := cmd.Context()
 
 			var clusterId string
 			var bucketURI, accessKeyID, secretAccessKey, database, table, targetType, fileType, compression string
@@ -139,12 +140,12 @@ func CreateCmd(h *internal.Helper) *cobra.Command {
 					return errors.New("The terminal doesn't support interactive mode, please use non-interactive mode")
 				}
 
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
 
-				cluster, err := cloud.GetSelectedCluster(project.ID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, project.ID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
@@ -275,7 +276,7 @@ func CreateCmd(h *internal.Helper) *cobra.Command {
 							},
 						},
 					},
-				})
+				}).WithContext(ctx)
 			if compression != "" {
 				params.Body.ExportOptions.Compression = exportModel.ExportOptionsCompressionType(compression)
 			}

--- a/internal/cli/serverless/export/describe.go
+++ b/internal/cli/serverless/export/describe.go
@@ -83,6 +83,7 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ctx := cmd.Context()
 
 			var exportID string
 			var clusterID string
@@ -92,17 +93,17 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 				}
 
 				// interactive mode
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
-				cluster, err := cloud.GetSelectedCluster(project.ID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, project.ID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
 				clusterID = cluster.ID
 
-				export, err := cloud.GetSelectedExport(clusterID, h.QueryPageSize, d)
+				export, err := cloud.GetSelectedExport(ctx, clusterID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
@@ -121,7 +122,7 @@ func DescribeCmd(h *internal.Helper) *cobra.Command {
 			}
 
 			params := exportApi.NewExportServiceGetExportParams().
-				WithClusterID(clusterID).WithExportID(exportID)
+				WithClusterID(clusterID).WithExportID(exportID).WithContext(ctx)
 			export, err := d.GetExport(params)
 			if err != nil {
 				return errors.Trace(err)

--- a/internal/cli/serverless/export/list.go
+++ b/internal/cli/serverless/export/list.go
@@ -84,6 +84,7 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ctx := cmd.Context()
 
 			var clusterID string
 			if opts.interactive {
@@ -91,11 +92,11 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 					return errors.New("The terminal doesn't support interactive mode, please use non-interactive mode")
 				}
 
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
-				cluster, err := cloud.GetSelectedCluster(project.ID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, project.ID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
@@ -107,7 +108,7 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 				}
 			}
 
-			total, items, err := cloud.RetrieveExports(clusterID, h.QueryPageSize, d)
+			total, items, err := cloud.RetrieveExports(ctx, clusterID, h.QueryPageSize, d)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/serverless/list.go
+++ b/internal/cli/serverless/list.go
@@ -73,6 +73,7 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 			}
 
 			var pID string
+			context := cmd.Context()
 			if opts.interactive {
 				cmd.Annotations[telemetry.InteractiveMode] = "true"
 				if !h.IOStreams.CanPrompt {
@@ -80,7 +81,7 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 				}
 
 				// interactive mode
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(context, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
@@ -94,7 +95,7 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 
 			cmd.Annotations[telemetry.ProjectID] = pID
 
-			total, items, err := cloud.RetrieveClusters(pID, h.QueryPageSize, d)
+			total, items, err := cloud.RetrieveClusters(context, pID, h.QueryPageSize, d)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/serverless/list_test.go
+++ b/internal/cli/serverless/list_test.go
@@ -16,6 +16,7 @@ package serverless
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -179,6 +180,7 @@ func (suite *ListClusterSuite) SetupTest() {
 
 func (suite *ListClusterSuite) TestListClusterArgs() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
 
 	body := &serverlessModel.TidbCloudOpenApiserverlessv1beta1ListClustersResponse{}
 	err := json.Unmarshal([]byte(listResultStr), body)
@@ -190,7 +192,7 @@ func (suite *ListClusterSuite) TestListClusterArgs() {
 	pageSize := int32(suite.h.QueryPageSize)
 	filter := fmt.Sprintf("projectId=%s", projectID)
 	suite.mockClient.On("ListClustersOfProject", serverlessApi.NewServerlessServiceListClustersParams().
-		WithPageSize(&pageSize).WithFilter(&filter)).
+		WithPageSize(&pageSize).WithFilter(&filter).WithContext(ctx)).
 		Return(result, nil)
 
 	tests := []struct {
@@ -220,6 +222,7 @@ func (suite *ListClusterSuite) TestListClusterArgs() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			cmd := ListCmd(suite.h)
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)
@@ -237,6 +240,8 @@ func (suite *ListClusterSuite) TestListClusterArgs() {
 
 func (suite *ListClusterSuite) TestListClusterWithMultiPages() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
+
 	suite.h.QueryPageSize = 1
 	pageSize := int32(suite.h.QueryPageSize)
 	pageToken := "2"
@@ -250,7 +255,7 @@ func (suite *ListClusterSuite) TestListClusterWithMultiPages() {
 	projectID := "12345"
 	filter := fmt.Sprintf("projectId=%s", projectID)
 	suite.mockClient.On("ListClustersOfProject", serverlessApi.NewServerlessServiceListClustersParams().
-		WithPageSize(&pageSize).WithFilter(&filter)).
+		WithPageSize(&pageSize).WithFilter(&filter).WithContext(ctx)).
 		Return(result, nil)
 
 	body2 := &serverlessModel.TidbCloudOpenApiserverlessv1beta1ListClustersResponse{}
@@ -260,7 +265,7 @@ func (suite *ListClusterSuite) TestListClusterWithMultiPages() {
 		Payload: body2,
 	}
 	suite.mockClient.On("ListClustersOfProject", serverlessApi.NewServerlessServiceListClustersParams().
-		WithPageToken(&pageToken).WithPageSize(&pageSize).WithFilter(&filter)).
+		WithPageToken(&pageToken).WithPageSize(&pageSize).WithFilter(&filter).WithContext(ctx)).
 		Return(result2, nil)
 	cmd := ListCmd(suite.h)
 
@@ -279,6 +284,7 @@ func (suite *ListClusterSuite) TestListClusterWithMultiPages() {
 
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)

--- a/internal/cli/serverless/region.go
+++ b/internal/cli/serverless/region.go
@@ -16,6 +16,7 @@ package serverless
 
 import (
 	"fmt"
+
 	"tidbcloud-cli/internal/flag"
 	"tidbcloud-cli/internal/output"
 
@@ -45,7 +46,7 @@ func RegionCmd(h *internal.Helper) *cobra.Command {
 				return errors.Trace(err)
 			}
 
-			regions, err := d.ListProviderRegions(serverlessApi.NewServerlessServiceListRegionsParams())
+			regions, err := d.ListProviderRegions(serverlessApi.NewServerlessServiceListRegionsParams().WithContext(cmd.Context()))
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/internal/cli/serverless/restore.go
+++ b/internal/cli/serverless/restore.go
@@ -95,6 +95,7 @@ func RestoreCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ctx := cmd.Context()
 
 			var clusterID string
 			var backupID string
@@ -107,25 +108,25 @@ func RestoreCmd(h *internal.Helper) *cobra.Command {
 				}
 
 				if restoreMode == cloud.RestoreModeSnapshot {
-					project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+					project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 					if err != nil {
 						return err
 					}
-					cluster, err := cloud.GetSelectedCluster(project.ID, h.QueryPageSize, d)
+					cluster, err := cloud.GetSelectedCluster(ctx, project.ID, h.QueryPageSize, d)
 					if err != nil {
 						return err
 					}
-					backup, err := cloud.GetSelectedServerlessBackup(cluster.ID, int32(h.QueryPageSize), d)
+					backup, err := cloud.GetSelectedServerlessBackup(ctx, cluster.ID, int32(h.QueryPageSize), d)
 					if err != nil {
 						return err
 					}
 					backupID = backup.ID
 				} else if restoreMode == cloud.RestoreModePointInTime {
-					project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+					project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 					if err != nil {
 						return err
 					}
-					cluster, err := cloud.GetSelectedCluster(project.ID, h.QueryPageSize, d)
+					cluster, err := cloud.GetSelectedCluster(ctx, project.ID, h.QueryPageSize, d)
 					if err != nil {
 						return err
 					}
@@ -154,7 +155,7 @@ func RestoreCmd(h *internal.Helper) *cobra.Command {
 				}
 			}
 
-			params := brApi.NewBackupRestoreServiceRestoreParams().WithBody(&brModel.V1beta1RestoreRequest{})
+			params := brApi.NewBackupRestoreServiceRestoreParams().WithBody(&brModel.V1beta1RestoreRequest{}).WithContext(ctx)
 			if backupID != "" {
 				params.Body.Snapshot = &brModel.RestoreRequestSnapshot{
 					BackupID: backupID,

--- a/internal/cli/serverless/restore_test.go
+++ b/internal/cli/serverless/restore_test.go
@@ -16,6 +16,7 @@ package serverless
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -57,6 +58,7 @@ func (suite *RestoreClusterSuite) SetupTest() {
 
 func (suite *RestoreClusterSuite) TestRestoreClusterSnapshot() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
 
 	clusterID := "10048930788495339885"
 	backupID := "289048"
@@ -67,7 +69,7 @@ func (suite *RestoreClusterSuite) TestRestoreClusterSnapshot() {
 		},
 	}
 	suite.mockClient.On("Restore", brApi.NewBackupRestoreServiceRestoreParams().
-		WithBody(body)).
+		WithBody(body).WithContext(ctx)).
 		Return(&brApi.BackupRestoreServiceRestoreOK{Payload: &brModel.V1beta1RestoreResponse{
 			ClusterID: &clusterID}}, nil)
 
@@ -88,6 +90,7 @@ func (suite *RestoreClusterSuite) TestRestoreClusterSnapshot() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			cmd := RestoreCmd(suite.h)
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)
@@ -105,6 +108,7 @@ func (suite *RestoreClusterSuite) TestRestoreClusterSnapshot() {
 
 func (suite *RestoreClusterSuite) TestRestoreClusterPointInTime() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
 
 	clusterID := "10048930788495339885"
 	backupTimeStr := "2023-12-15T07:00:00.000Z"
@@ -118,7 +122,7 @@ func (suite *RestoreClusterSuite) TestRestoreClusterPointInTime() {
 		},
 	}
 	suite.mockClient.On("Restore", brApi.NewBackupRestoreServiceRestoreParams().
-		WithBody(body)).
+		WithBody(body).WithContext(ctx)).
 		Return(&brApi.BackupRestoreServiceRestoreOK{Payload: &brModel.V1beta1RestoreResponse{
 			ClusterID: &clusterID}}, nil)
 
@@ -139,6 +143,7 @@ func (suite *RestoreClusterSuite) TestRestoreClusterPointInTime() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			cmd := RestoreCmd(suite.h)
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)

--- a/internal/cli/serverless/shell.go
+++ b/internal/cli/serverless/shell.go
@@ -102,13 +102,13 @@ The connection forces the [ANSI SQL mode](https://dev.mysql.com/doc/refman/8.0/e
 			var pass *string
 			if opts.interactive {
 				// interactive mode
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
 				projectID := project.ID
 
-				cluster, err := cloud.GetSelectedCluster(projectID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, projectID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
@@ -168,7 +168,7 @@ The connection forces the [ANSI SQL mode](https://dev.mysql.com/doc/refman/8.0/e
 			}
 
 			var host, name, port string
-			params := serverlessApi.NewServerlessServiceGetClusterParams().WithClusterID(clusterID)
+			params := serverlessApi.NewServerlessServiceGetClusterParams().WithClusterID(clusterID).WithContext(ctx)
 			cluster, err := d.GetCluster(params)
 			if err != nil {
 				return errors.Trace(err)

--- a/internal/cli/serverless/spending_limit.go
+++ b/internal/cli/serverless/spending_limit.go
@@ -89,6 +89,7 @@ func SpendingLimitCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ctx := cmd.Context()
 
 			var clusterID string
 			var monthly int32
@@ -98,12 +99,12 @@ func SpendingLimitCmd(h *internal.Helper) *cobra.Command {
 				}
 
 				// interactive mode
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
 
-				cluster, err := cloud.GetSelectedCluster(project.ID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, project.ID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
@@ -151,7 +152,8 @@ func SpendingLimitCmd(h *internal.Helper) *cobra.Command {
 			}
 			body.UpdateMask = &SpendingLimitMonthlyMask
 			body.Cluster.SpendingLimit.Monthly = monthly
-			params := serverlessApi.NewServerlessServicePartialUpdateClusterParams().WithClusterClusterID(clusterID).WithBody(*body)
+			params := serverlessApi.NewServerlessServicePartialUpdateClusterParams().WithClusterClusterID(clusterID).
+				WithBody(*body).WithContext(ctx)
 			_, err = d.PartialUpdateCluster(params)
 			if err != nil {
 				return errors.Trace(err)

--- a/internal/cli/serverless/spending_limit_test.go
+++ b/internal/cli/serverless/spending_limit_test.go
@@ -16,6 +16,7 @@ package serverless
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -55,6 +56,7 @@ func (suite *SpendingLimitSuite) SetupTest() {
 
 func (suite *SpendingLimitSuite) TestSetSpendingLimit() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
 
 	clusterID := "0"
 	monthly := 10
@@ -69,7 +71,7 @@ func (suite *SpendingLimitSuite) TestSetSpendingLimit() {
 	}
 
 	suite.mockClient.On("PartialUpdateCluster", serverlessApi.NewServerlessServicePartialUpdateClusterParams().
-		WithClusterClusterID(clusterID).WithBody(body)).
+		WithClusterClusterID(clusterID).WithBody(body).WithContext(ctx)).
 		Return(&serverlessApi.ServerlessServicePartialUpdateClusterOK{}, nil)
 
 	tests := []struct {
@@ -89,6 +91,7 @@ func (suite *SpendingLimitSuite) TestSetSpendingLimit() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			cmd := SpendingLimitCmd(suite.h)
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)

--- a/internal/cli/serverless/update.go
+++ b/internal/cli/serverless/update.go
@@ -102,6 +102,7 @@ func UpdateCmd(h *internal.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ctx := cmd.Context()
 
 			var clusterID string
 			var fieldName string
@@ -113,12 +114,12 @@ func UpdateCmd(h *internal.Helper) *cobra.Command {
 				}
 
 				// interactive mode
-				project, err := cloud.GetSelectedProject(h.QueryPageSize, d)
+				project, err := cloud.GetSelectedProject(ctx, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
 
-				cluster, err := cloud.GetSelectedCluster(project.ID, h.QueryPageSize, d)
+				cluster, err := cloud.GetSelectedCluster(ctx, project.ID, h.QueryPageSize, d)
 				if err != nil {
 					return err
 				}
@@ -192,7 +193,8 @@ func UpdateCmd(h *internal.Helper) *cobra.Command {
 			}
 			body.UpdateMask = &fieldName
 
-			params := serverlessApi.NewServerlessServicePartialUpdateClusterParams().WithClusterClusterID(clusterID).WithBody(*body)
+			params := serverlessApi.NewServerlessServicePartialUpdateClusterParams().WithClusterClusterID(clusterID).
+				WithBody(*body).WithContext(ctx)
 			_, err = d.PartialUpdateCluster(params)
 			if err != nil {
 				return errors.Trace(err)

--- a/internal/cli/serverless/update_test.go
+++ b/internal/cli/serverless/update_test.go
@@ -16,6 +16,7 @@ package serverless
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -55,6 +56,7 @@ func (suite *UpdateClusterSuite) SetupTest() {
 
 func (suite *UpdateClusterSuite) TestUpdateClusterArgs() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
 
 	displayName := "update_name"
 	cluster := &serverlessApi.ServerlessServicePartialUpdateClusterParamsBodyCluster{
@@ -68,7 +70,7 @@ func (suite *UpdateClusterSuite) TestUpdateClusterArgs() {
 
 	clusterID := "12345"
 	suite.mockClient.On("PartialUpdateCluster", serverlessApi.NewServerlessServicePartialUpdateClusterParams().
-		WithClusterClusterID(clusterID).WithBody(body)).
+		WithClusterClusterID(clusterID).WithBody(body).WithContext(ctx)).
 		Return(&serverlessApi.ServerlessServicePartialUpdateClusterOK{}, nil)
 
 	tests := []struct {
@@ -88,6 +90,7 @@ func (suite *UpdateClusterSuite) TestUpdateClusterArgs() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			cmd := UpdateCmd(suite.h)
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)
@@ -105,6 +108,7 @@ func (suite *UpdateClusterSuite) TestUpdateClusterArgs() {
 
 func (suite *UpdateClusterSuite) TestUpdateLabels() {
 	assert := require.New(suite.T())
+	ctx := context.Background()
 
 	labels := "{\"labels\":\"values\"}"
 	mask := "labels"
@@ -120,7 +124,7 @@ func (suite *UpdateClusterSuite) TestUpdateLabels() {
 	}
 	clusterID := "12345"
 	suite.mockClient.On("PartialUpdateCluster", serverlessApi.NewServerlessServicePartialUpdateClusterParams().
-		WithClusterClusterID(clusterID).WithBody(body)).
+		WithClusterClusterID(clusterID).WithBody(body).WithContext(ctx)).
 		Return(&serverlessApi.ServerlessServicePartialUpdateClusterOK{}, nil)
 
 	tests := []struct {
@@ -140,6 +144,7 @@ func (suite *UpdateClusterSuite) TestUpdateLabels() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			cmd := UpdateCmd(suite.h)
+			cmd.SetContext(ctx)
 			suite.h.IOStreams.Out.(*bytes.Buffer).Reset()
 			suite.h.IOStreams.Err.(*bytes.Buffer).Reset()
 			cmd.SetArgs(tt.args)

--- a/internal/service/cloud/logic.go
+++ b/internal/service/cloud/logic.go
@@ -113,8 +113,8 @@ func (i Import) String() string {
 	return fmt.Sprintf("%s(%s)", i.ID, *i.Status)
 }
 
-func GetSelectedProject(pageSize int64, client TiDBCloudClient) (*Project, error) {
-	_, projectItems, err := RetrieveProjects(pageSize, client)
+func GetSelectedProject(ctx context.Context, pageSize int64, client TiDBCloudClient) (*Project, error) {
+	_, projectItems, err := RetrieveProjects(ctx, pageSize, client)
 	if err != nil {
 		return nil, err
 	}
@@ -157,8 +157,8 @@ func GetSelectedProject(pageSize int64, client TiDBCloudClient) (*Project, error
 	return res.(*Project), nil
 }
 
-func GetSelectedCluster(projectID string, pageSize int64, client TiDBCloudClient) (*Cluster, error) {
-	_, clusterItems, err := RetrieveClusters(projectID, pageSize, client)
+func GetSelectedCluster(ctx context.Context, projectID string, pageSize int64, client TiDBCloudClient) (*Cluster, error) {
+	_, clusterItems, err := RetrieveClusters(ctx, projectID, pageSize, client)
 	if err != nil {
 		return nil, err
 	}
@@ -253,8 +253,8 @@ func GetSpendingLimitField(mutableFields []string) (string, error) {
 	return field.(string), nil
 }
 
-func GetSelectedBranch(clusterID string, pageSize int64, client TiDBCloudClient) (*Branch, error) {
-	_, branchItems, err := RetrieveBranches(clusterID, pageSize, client)
+func GetSelectedBranch(ctx context.Context, clusterID string, pageSize int64, client TiDBCloudClient) (*Branch, error) {
+	_, branchItems, err := RetrieveBranches(ctx, clusterID, pageSize, client)
 	if err != nil {
 		return nil, err
 	}
@@ -294,8 +294,8 @@ func GetSelectedBranch(clusterID string, pageSize int64, client TiDBCloudClient)
 	return branch.(*Branch), nil
 }
 
-func GetSelectedExport(clusterID string, pageSize int64, client TiDBCloudClient) (*Export, error) {
-	_, exportItems, err := RetrieveExports(clusterID, pageSize, client)
+func GetSelectedExport(ctx context.Context, clusterID string, pageSize int64, client TiDBCloudClient) (*Export, error) {
+	_, exportItems, err := RetrieveExports(ctx, clusterID, pageSize, client)
 	if err != nil {
 		return nil, err
 	}
@@ -333,8 +333,8 @@ func GetSelectedExport(clusterID string, pageSize int64, client TiDBCloudClient)
 	return export.(*Export), nil
 }
 
-func GetSelectedLocalExport(clusterID string, pageSize int64, client TiDBCloudClient) (*Export, error) {
-	_, exportItems, err := RetrieveExports(clusterID, pageSize, client)
+func GetSelectedLocalExport(ctx context.Context, clusterID string, pageSize int64, client TiDBCloudClient) (*Export, error) {
+	_, exportItems, err := RetrieveExports(ctx, clusterID, pageSize, client)
 	if err != nil {
 		return nil, err
 	}
@@ -374,8 +374,8 @@ func GetSelectedLocalExport(clusterID string, pageSize int64, client TiDBCloudCl
 	return export.(*Export), nil
 }
 
-func GetSelectedServerlessBackup(clusterID string, pageSize int32, client TiDBCloudClient) (*ServerlessBackup, error) {
-	_, backupItems, err := RetrieveServerlessBackups(clusterID, pageSize, client)
+func GetSelectedServerlessBackup(ctx context.Context, clusterID string, pageSize int32, client TiDBCloudClient) (*ServerlessBackup, error) {
+	_, backupItems, err := RetrieveServerlessBackups(ctx, clusterID, pageSize, client)
 	if err != nil {
 		return nil, err
 	}
@@ -484,11 +484,11 @@ func GetSelectedImport(ctx context.Context, cID string, pageSize int64, client T
 	return res.(*Import), nil
 }
 
-func RetrieveProjects(pageSize int64, d TiDBCloudClient) (int64, []*iamModel.APIProject, error) {
+func RetrieveProjects(ctx context.Context, pageSize int64, d TiDBCloudClient) (int64, []*iamModel.APIProject, error) {
 	var items []*iamModel.APIProject
 	var pageToken string
 
-	params := iamApi.NewGetV1beta1ProjectsParams().WithPageSize(&pageSize)
+	params := iamApi.NewGetV1beta1ProjectsParams().WithPageSize(&pageSize).WithContext(ctx)
 	projects, err := d.ListProjects(params)
 	if err != nil {
 		return 0, nil, errors.Trace(err)
@@ -509,8 +509,8 @@ func RetrieveProjects(pageSize int64, d TiDBCloudClient) (int64, []*iamModel.API
 	return int64(len(items)), items, nil
 }
 
-func RetrieveClusters(pID string, pageSize int64, d TiDBCloudClient) (int64, []*serverlessModel.TidbCloudOpenApiserverlessv1beta1Cluster, error) {
-	params := serverlessApi.NewServerlessServiceListClustersParams()
+func RetrieveClusters(ctx context.Context, pID string, pageSize int64, d TiDBCloudClient) (int64, []*serverlessModel.TidbCloudOpenApiserverlessv1beta1Cluster, error) {
+	params := serverlessApi.NewServerlessServiceListClustersParams().WithContext(ctx)
 	if pID != "" {
 		projectFilter := fmt.Sprintf("projectId=%s", pID)
 		params.WithFilter(&projectFilter)
@@ -537,12 +537,12 @@ func RetrieveClusters(pID string, pageSize int64, d TiDBCloudClient) (int64, []*
 	return int64(len(items)), items, nil
 }
 
-func RetrieveBranches(cID string, pageSize int64, d TiDBCloudClient) (int64, []*branchModel.V1beta1Branch, error) {
+func RetrieveBranches(ctx context.Context, cID string, pageSize int64, d TiDBCloudClient) (int64, []*branchModel.V1beta1Branch, error) {
 	var items []*branchModel.V1beta1Branch
 	pageSizeInt32 := int32(pageSize)
 	var pageToken string
 
-	params := branchApi.NewBranchServiceListBranchesParams().WithClusterID(cID)
+	params := branchApi.NewBranchServiceListBranchesParams().WithClusterID(cID).WithContext(ctx)
 	branches, err := d.ListBranches(params.WithPageSize(&pageSizeInt32))
 	if err != nil {
 		return 0, nil, errors.Trace(err)
@@ -563,12 +563,12 @@ func RetrieveBranches(cID string, pageSize int64, d TiDBCloudClient) (int64, []*
 	return int64(len(items)), items, nil
 }
 
-func RetrieveExports(cID string, pageSize int64, d TiDBCloudClient) (int64, []*exportModel.V1beta1Export, error) {
+func RetrieveExports(ctx context.Context, cID string, pageSize int64, d TiDBCloudClient) (int64, []*exportModel.V1beta1Export, error) {
 	var items []*exportModel.V1beta1Export
 	pageSizeInt32 := int32(pageSize)
 	var pageToken string
 
-	params := exportApi.NewExportServiceListExportsParams().WithClusterID(cID).WithPageSize(&pageSizeInt32)
+	params := exportApi.NewExportServiceListExportsParams().WithClusterID(cID).WithPageSize(&pageSizeInt32).WithContext(ctx)
 	exports, err := d.ListExports(params)
 	if err != nil {
 		return 0, nil, errors.Trace(err)
@@ -589,11 +589,11 @@ func RetrieveExports(cID string, pageSize int64, d TiDBCloudClient) (int64, []*e
 	return int64(len(items)), items, nil
 }
 
-func RetrieveServerlessBackups(cID string, pageSize int32, d TiDBCloudClient) (int64, []*brModel.V1beta1Backup, error) {
+func RetrieveServerlessBackups(ctx context.Context, cID string, pageSize int32, d TiDBCloudClient) (int64, []*brModel.V1beta1Backup, error) {
 	var items []*brModel.V1beta1Backup
 	var pageToken string
 
-	params := brApi.NewBackupRestoreServiceListBackupsParams().WithClusterID(cID)
+	params := brApi.NewBackupRestoreServiceListBackupsParams().WithClusterID(cID).WithContext(ctx)
 	backups, err := d.ListBackups(params.WithPageSize(&pageSize))
 	if err != nil {
 		return 0, nil, errors.Trace(err)


### PR DESCRIPTION
## What is the purpose of the change

close https://github.com/tidbcloud/tidbcloud-cli/issues/158

## Brief change log

- Add context to tidbcloud client.
- Use filepath.Join() to join the file path.
