### PR TITLE
Remove url when export download error

### DIFF
--- a/internal/util/download.go
+++ b/internal/util/download.go
@@ -33,7 +33,7 @@ func GetResponse(url string, debug bool) (*http.Response, error) {
 	}
 	if resp.StatusCode != http.StatusOK {
 		resp.Body.Close()
-		return nil, fmt.Errorf("receiving status of %d for url: %s", resp.StatusCode, url)
+		return nil, fmt.Errorf("receiving status of %d", resp.StatusCode)
 	}
 	if resp.ContentLength <= 0 {
 		resp.Body.Close()


### PR DESCRIPTION
## What is the purpose of the change

<!-- (For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).) -->

## Brief change log

<!-- *(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache* -->
