### PR TITLE
set AutoPrefix to true when creating a sql user

### DIFF
--- a/internal/cli/serverless/sqluser/create.go
+++ b/internal/cli/serverless/sqluser/create.go
@@ -205,6 +205,7 @@ func CreateCmd(h *internal.Helper) *cobra.Command {
 					Password:    password,
 					BuiltinRole: builtinRole,
 					CustomRoles: customRoles,
+					AutoPrefix:  true,
 				}).
 				WithContext(ctx)
 

--- a/internal/cli/serverless/sqluser/create_test.go
+++ b/internal/cli/serverless/sqluser/create_test.go
@@ -93,6 +93,7 @@ func (suite *CreateSQLUserSuite) TestCreateSQLUserArgs() {
 		CustomRoles: customRole,
 		Password:    password,
 		AuthMethod:  util.MYSQLNATIVEPASSWORD,
+		AutoPrefix:  true,
 	}
 	body := &iamModel.APISQLUser{}
 	err := json.Unmarshal([]byte(getSQLUserResultStr), body)


### PR DESCRIPTION
## What is the purpose of the change

<!-- (For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).) -->

## Brief change log

<!-- *(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache* -->
