### PR TITLE
Support export order by

### DIFF
--- a/internal/cli/serverless/export/create.go
+++ b/internal/cli/serverless/export/create.go
@@ -538,7 +538,7 @@ func initialFilterInputModel(filterType FilterType) ui.TextInputModel {
 			t.PromptStyle = config.FocusedStyle
 			t.TextStyle = config.FocusedStyle
 		case flag.TableFilter:
-			t.Placeholder = "Table filter patterns (comma separated). Example: test.t,test1.*,`test-2`.`t-2`"
+			t.Placeholder = "Table filter patterns (comma separated). Example: database.table,database.*,`database-1`.`table-1`"
 			t.Focus()
 			t.PromptStyle = config.FocusedStyle
 			t.TextStyle = config.FocusedStyle

--- a/internal/cli/serverless/export/create.go
+++ b/internal/cli/serverless/export/create.go
@@ -538,7 +538,7 @@ func initialFilterInputModel(filterType FilterType) ui.TextInputModel {
 			t.PromptStyle = config.FocusedStyle
 			t.TextStyle = config.FocusedStyle
 		case flag.TableFilter:
-			t.Placeholder = "Table filter patterns (comma separated). Example: test1.t1,test.*"
+			t.Placeholder = "Table filter patterns (comma separated). Example: test.t,test1.*,`test-2`.`t-2`"
 			t.Focus()
 			t.PromptStyle = config.FocusedStyle
 			t.TextStyle = config.FocusedStyle

--- a/internal/service/cloud/logic.go
+++ b/internal/service/cloud/logic.go
@@ -652,7 +652,9 @@ func RetrieveExports(ctx context.Context, cID string, pageSize int64, d TiDBClou
 	pageSizeInt32 := int32(pageSize)
 	var pageToken string
 
-	params := exportApi.NewExportServiceListExportsParams().WithClusterID(cID).WithPageSize(&pageSizeInt32).WithContext(ctx)
+	orderBy := "create_time desc"
+	params := exportApi.NewExportServiceListExportsParams().WithClusterID(cID).WithPageSize(&pageSizeInt32).
+		WithOrderBy(&orderBy).WithContext(ctx)
 	exports, err := d.ListExports(params)
 	if err != nil {
 		return 0, nil, errors.Trace(err)

--- a/pkg/tidbcloud/v1beta1/branch/client/branch_service/branch_service_client.go
+++ b/pkg/tidbcloud/v1beta1/branch/client/branch_service/branch_service_client.go
@@ -7,12 +7,38 @@ package branch_service
 
 import (
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new branch service API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new branch service API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new branch service API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -23,7 +49,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/pkg/tidbcloud/v1beta1/branch/client/branch_service/branch_service_create_branch_responses.go
+++ b/pkg/tidbcloud/v1beta1/branch/client/branch_service/branch_service_create_branch_responses.go
@@ -6,6 +6,7 @@ package branch_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *BranchServiceCreateBranchOK) Code() int {
 }
 
 func (o *BranchServiceCreateBranchOK) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/branches][%d] branchServiceCreateBranchOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/branches][%d] branchServiceCreateBranchOK %s", 200, payload)
 }
 
 func (o *BranchServiceCreateBranchOK) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/branches][%d] branchServiceCreateBranchOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/branches][%d] branchServiceCreateBranchOK %s", 200, payload)
 }
 
 func (o *BranchServiceCreateBranchOK) GetPayload() *models.V1beta1Branch {
@@ -158,11 +161,13 @@ func (o *BranchServiceCreateBranchDefault) Code() int {
 }
 
 func (o *BranchServiceCreateBranchDefault) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/branches][%d] BranchService_CreateBranch default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/branches][%d] BranchService_CreateBranch default %s", o._statusCode, payload)
 }
 
 func (o *BranchServiceCreateBranchDefault) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/branches][%d] BranchService_CreateBranch default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/branches][%d] BranchService_CreateBranch default %s", o._statusCode, payload)
 }
 
 func (o *BranchServiceCreateBranchDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/branch/client/branch_service/branch_service_delete_branch_responses.go
+++ b/pkg/tidbcloud/v1beta1/branch/client/branch_service/branch_service_delete_branch_responses.go
@@ -6,6 +6,7 @@ package branch_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *BranchServiceDeleteBranchOK) Code() int {
 }
 
 func (o *BranchServiceDeleteBranchOK) Error() string {
-	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/branches/{branchId}][%d] branchServiceDeleteBranchOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/branches/{branchId}][%d] branchServiceDeleteBranchOK %s", 200, payload)
 }
 
 func (o *BranchServiceDeleteBranchOK) String() string {
-	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/branches/{branchId}][%d] branchServiceDeleteBranchOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/branches/{branchId}][%d] branchServiceDeleteBranchOK %s", 200, payload)
 }
 
 func (o *BranchServiceDeleteBranchOK) GetPayload() *models.V1beta1Branch {
@@ -158,11 +161,13 @@ func (o *BranchServiceDeleteBranchDefault) Code() int {
 }
 
 func (o *BranchServiceDeleteBranchDefault) Error() string {
-	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/branches/{branchId}][%d] BranchService_DeleteBranch default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/branches/{branchId}][%d] BranchService_DeleteBranch default %s", o._statusCode, payload)
 }
 
 func (o *BranchServiceDeleteBranchDefault) String() string {
-	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/branches/{branchId}][%d] BranchService_DeleteBranch default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/branches/{branchId}][%d] BranchService_DeleteBranch default %s", o._statusCode, payload)
 }
 
 func (o *BranchServiceDeleteBranchDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/branch/client/branch_service/branch_service_get_branch_responses.go
+++ b/pkg/tidbcloud/v1beta1/branch/client/branch_service/branch_service_get_branch_responses.go
@@ -6,6 +6,7 @@ package branch_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *BranchServiceGetBranchOK) Code() int {
 }
 
 func (o *BranchServiceGetBranchOK) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/branches/{branchId}][%d] branchServiceGetBranchOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/branches/{branchId}][%d] branchServiceGetBranchOK %s", 200, payload)
 }
 
 func (o *BranchServiceGetBranchOK) String() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/branches/{branchId}][%d] branchServiceGetBranchOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/branches/{branchId}][%d] branchServiceGetBranchOK %s", 200, payload)
 }
 
 func (o *BranchServiceGetBranchOK) GetPayload() *models.V1beta1Branch {
@@ -158,11 +161,13 @@ func (o *BranchServiceGetBranchDefault) Code() int {
 }
 
 func (o *BranchServiceGetBranchDefault) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/branches/{branchId}][%d] BranchService_GetBranch default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/branches/{branchId}][%d] BranchService_GetBranch default %s", o._statusCode, payload)
 }
 
 func (o *BranchServiceGetBranchDefault) String() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/branches/{branchId}][%d] BranchService_GetBranch default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/branches/{branchId}][%d] BranchService_GetBranch default %s", o._statusCode, payload)
 }
 
 func (o *BranchServiceGetBranchDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/branch/client/branch_service/branch_service_list_branches_responses.go
+++ b/pkg/tidbcloud/v1beta1/branch/client/branch_service/branch_service_list_branches_responses.go
@@ -6,6 +6,7 @@ package branch_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *BranchServiceListBranchesOK) Code() int {
 }
 
 func (o *BranchServiceListBranchesOK) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/branches][%d] branchServiceListBranchesOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/branches][%d] branchServiceListBranchesOK %s", 200, payload)
 }
 
 func (o *BranchServiceListBranchesOK) String() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/branches][%d] branchServiceListBranchesOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/branches][%d] branchServiceListBranchesOK %s", 200, payload)
 }
 
 func (o *BranchServiceListBranchesOK) GetPayload() *models.V1beta1ListBranchesResponse {
@@ -158,11 +161,13 @@ func (o *BranchServiceListBranchesDefault) Code() int {
 }
 
 func (o *BranchServiceListBranchesDefault) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/branches][%d] BranchService_ListBranches default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/branches][%d] BranchService_ListBranches default %s", o._statusCode, payload)
 }
 
 func (o *BranchServiceListBranchesDefault) String() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/branches][%d] BranchService_ListBranches default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/branches][%d] BranchService_ListBranches default %s", o._statusCode, payload)
 }
 
 func (o *BranchServiceListBranchesDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/branch/models/protobuf_any.go
+++ b/pkg/tidbcloud/v1beta1/branch/models/protobuf_any.go
@@ -7,6 +7,7 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -19,6 +20,82 @@ type ProtobufAny struct {
 
 	// at type
 	AtType string `json:"@type,omitempty"`
+
+	// protobuf any
+	ProtobufAny map[string]interface{} `json:"-"`
+}
+
+// UnmarshalJSON unmarshals this object with additional properties from JSON
+func (m *ProtobufAny) UnmarshalJSON(data []byte) error {
+	// stage 1, bind the properties
+	var stage1 struct {
+
+		// at type
+		AtType string `json:"@type,omitempty"`
+	}
+	if err := json.Unmarshal(data, &stage1); err != nil {
+		return err
+	}
+	var rcv ProtobufAny
+
+	rcv.AtType = stage1.AtType
+	*m = rcv
+
+	// stage 2, remove properties and add to map
+	stage2 := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(data, &stage2); err != nil {
+		return err
+	}
+
+	delete(stage2, "@type")
+	// stage 3, add additional properties values
+	if len(stage2) > 0 {
+		result := make(map[string]interface{})
+		for k, v := range stage2 {
+			var toadd interface{}
+			if err := json.Unmarshal(v, &toadd); err != nil {
+				return err
+			}
+			result[k] = toadd
+		}
+		m.ProtobufAny = result
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals this object with additional properties into a JSON object
+func (m ProtobufAny) MarshalJSON() ([]byte, error) {
+	var stage1 struct {
+
+		// at type
+		AtType string `json:"@type,omitempty"`
+	}
+
+	stage1.AtType = m.AtType
+
+	// make JSON object for known properties
+	props, err := json.Marshal(stage1)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(m.ProtobufAny) == 0 { // no additional properties
+		return props, nil
+	}
+
+	// make JSON object for the additional properties
+	additional, err := json.Marshal(m.ProtobufAny)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(props) < 3 { // "{}": only additional properties
+		return additional, nil
+	}
+
+	// concatenate the 2 objects
+	return swag.ConcatJSON(props, additional), nil
 }
 
 // Validate validates this protobuf any

--- a/pkg/tidbcloud/v1beta1/iam/client/account/account_client.go
+++ b/pkg/tidbcloud/v1beta1/iam/client/account/account_client.go
@@ -9,12 +9,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new account API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new account API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new account API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -25,7 +51,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/pkg/tidbcloud/v1beta1/iam/client/account/delete_v1beta1_clusters_cluster_id_sql_users_user_name_responses.go
+++ b/pkg/tidbcloud/v1beta1/iam/client/account/delete_v1beta1_clusters_cluster_id_sql_users_user_name_responses.go
@@ -6,6 +6,7 @@ package account
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -85,11 +86,13 @@ func (o *DeleteV1beta1ClustersClusterIDSQLUsersUserNameOK) Code() int {
 }
 
 func (o *DeleteV1beta1ClustersClusterIDSQLUsersUserNameOK) Error() string {
-	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] deleteV1beta1ClustersClusterIdSqlUsersUserNameOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] deleteV1beta1ClustersClusterIdSqlUsersUserNameOK %s", 200, payload)
 }
 
 func (o *DeleteV1beta1ClustersClusterIDSQLUsersUserNameOK) String() string {
-	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] deleteV1beta1ClustersClusterIdSqlUsersUserNameOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] deleteV1beta1ClustersClusterIdSqlUsersUserNameOK %s", 200, payload)
 }
 
 func (o *DeleteV1beta1ClustersClusterIDSQLUsersUserNameOK) GetPayload() *models.APIBasicResp {
@@ -153,11 +156,13 @@ func (o *DeleteV1beta1ClustersClusterIDSQLUsersUserNameBadRequest) Code() int {
 }
 
 func (o *DeleteV1beta1ClustersClusterIDSQLUsersUserNameBadRequest) Error() string {
-	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] deleteV1beta1ClustersClusterIdSqlUsersUserNameBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] deleteV1beta1ClustersClusterIdSqlUsersUserNameBadRequest %s", 400, payload)
 }
 
 func (o *DeleteV1beta1ClustersClusterIDSQLUsersUserNameBadRequest) String() string {
-	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] deleteV1beta1ClustersClusterIdSqlUsersUserNameBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] deleteV1beta1ClustersClusterIdSqlUsersUserNameBadRequest %s", 400, payload)
 }
 
 func (o *DeleteV1beta1ClustersClusterIDSQLUsersUserNameBadRequest) GetPayload() *models.APIOpenAPIError {

--- a/pkg/tidbcloud/v1beta1/iam/client/account/get_msp_customers_customer_org_id_responses.go
+++ b/pkg/tidbcloud/v1beta1/iam/client/account/get_msp_customers_customer_org_id_responses.go
@@ -6,6 +6,7 @@ package account
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -85,11 +86,13 @@ func (o *GetMspCustomersCustomerOrgIDOK) Code() int {
 }
 
 func (o *GetMspCustomersCustomerOrgIDOK) Error() string {
-	return fmt.Sprintf("[GET /mspCustomers/{customerOrgId}][%d] getMspCustomersCustomerOrgIdOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /mspCustomers/{customerOrgId}][%d] getMspCustomersCustomerOrgIdOK %s", 200, payload)
 }
 
 func (o *GetMspCustomersCustomerOrgIDOK) String() string {
-	return fmt.Sprintf("[GET /mspCustomers/{customerOrgId}][%d] getMspCustomersCustomerOrgIdOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /mspCustomers/{customerOrgId}][%d] getMspCustomersCustomerOrgIdOK %s", 200, payload)
 }
 
 func (o *GetMspCustomersCustomerOrgIDOK) GetPayload() *models.APIOpenAPIMspCustomer {
@@ -153,11 +156,13 @@ func (o *GetMspCustomersCustomerOrgIDBadRequest) Code() int {
 }
 
 func (o *GetMspCustomersCustomerOrgIDBadRequest) Error() string {
-	return fmt.Sprintf("[GET /mspCustomers/{customerOrgId}][%d] getMspCustomersCustomerOrgIdBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /mspCustomers/{customerOrgId}][%d] getMspCustomersCustomerOrgIdBadRequest %s", 400, payload)
 }
 
 func (o *GetMspCustomersCustomerOrgIDBadRequest) String() string {
-	return fmt.Sprintf("[GET /mspCustomers/{customerOrgId}][%d] getMspCustomersCustomerOrgIdBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /mspCustomers/{customerOrgId}][%d] getMspCustomersCustomerOrgIdBadRequest %s", 400, payload)
 }
 
 func (o *GetMspCustomersCustomerOrgIDBadRequest) GetPayload() *models.APIOpenAPIError {

--- a/pkg/tidbcloud/v1beta1/iam/client/account/get_msp_customers_responses.go
+++ b/pkg/tidbcloud/v1beta1/iam/client/account/get_msp_customers_responses.go
@@ -6,6 +6,7 @@ package account
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -85,11 +86,13 @@ func (o *GetMspCustomersOK) Code() int {
 }
 
 func (o *GetMspCustomersOK) Error() string {
-	return fmt.Sprintf("[GET /mspCustomers][%d] getMspCustomersOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /mspCustomers][%d] getMspCustomersOK %s", 200, payload)
 }
 
 func (o *GetMspCustomersOK) String() string {
-	return fmt.Sprintf("[GET /mspCustomers][%d] getMspCustomersOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /mspCustomers][%d] getMspCustomersOK %s", 200, payload)
 }
 
 func (o *GetMspCustomersOK) GetPayload() *models.APIOpenAPIListMspCustomerRsp {
@@ -153,11 +156,13 @@ func (o *GetMspCustomersBadRequest) Code() int {
 }
 
 func (o *GetMspCustomersBadRequest) Error() string {
-	return fmt.Sprintf("[GET /mspCustomers][%d] getMspCustomersBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /mspCustomers][%d] getMspCustomersBadRequest %s", 400, payload)
 }
 
 func (o *GetMspCustomersBadRequest) String() string {
-	return fmt.Sprintf("[GET /mspCustomers][%d] getMspCustomersBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /mspCustomers][%d] getMspCustomersBadRequest %s", 400, payload)
 }
 
 func (o *GetMspCustomersBadRequest) GetPayload() *models.APIOpenAPIError {

--- a/pkg/tidbcloud/v1beta1/iam/client/account/get_v1beta1_clusters_cluster_id_dbuser_responses.go
+++ b/pkg/tidbcloud/v1beta1/iam/client/account/get_v1beta1_clusters_cluster_id_dbuser_responses.go
@@ -6,6 +6,7 @@ package account
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -85,11 +86,13 @@ func (o *GetV1beta1ClustersClusterIDDbuserOK) Code() int {
 }
 
 func (o *GetV1beta1ClustersClusterIDDbuserOK) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/dbuser][%d] getV1beta1ClustersClusterIdDbuserOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/dbuser][%d] getV1beta1ClustersClusterIdDbuserOK %s", 200, payload)
 }
 
 func (o *GetV1beta1ClustersClusterIDDbuserOK) String() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/dbuser][%d] getV1beta1ClustersClusterIdDbuserOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/dbuser][%d] getV1beta1ClustersClusterIdDbuserOK %s", 200, payload)
 }
 
 func (o *GetV1beta1ClustersClusterIDDbuserOK) GetPayload() *models.APIGetDbuserRsp {
@@ -153,11 +156,13 @@ func (o *GetV1beta1ClustersClusterIDDbuserBadRequest) Code() int {
 }
 
 func (o *GetV1beta1ClustersClusterIDDbuserBadRequest) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/dbuser][%d] getV1beta1ClustersClusterIdDbuserBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/dbuser][%d] getV1beta1ClustersClusterIdDbuserBadRequest %s", 400, payload)
 }
 
 func (o *GetV1beta1ClustersClusterIDDbuserBadRequest) String() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/dbuser][%d] getV1beta1ClustersClusterIdDbuserBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/dbuser][%d] getV1beta1ClustersClusterIdDbuserBadRequest %s", 400, payload)
 }
 
 func (o *GetV1beta1ClustersClusterIDDbuserBadRequest) GetPayload() *models.APIOpenAPIError {

--- a/pkg/tidbcloud/v1beta1/iam/client/account/get_v1beta1_clusters_cluster_id_sql_users_responses.go
+++ b/pkg/tidbcloud/v1beta1/iam/client/account/get_v1beta1_clusters_cluster_id_sql_users_responses.go
@@ -6,6 +6,7 @@ package account
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -85,11 +86,13 @@ func (o *GetV1beta1ClustersClusterIDSQLUsersOK) Code() int {
 }
 
 func (o *GetV1beta1ClustersClusterIDSQLUsersOK) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/sqlUsers][%d] getV1beta1ClustersClusterIdSqlUsersOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/sqlUsers][%d] getV1beta1ClustersClusterIdSqlUsersOK %s", 200, payload)
 }
 
 func (o *GetV1beta1ClustersClusterIDSQLUsersOK) String() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/sqlUsers][%d] getV1beta1ClustersClusterIdSqlUsersOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/sqlUsers][%d] getV1beta1ClustersClusterIdSqlUsersOK %s", 200, payload)
 }
 
 func (o *GetV1beta1ClustersClusterIDSQLUsersOK) GetPayload() *models.APIListSQLUsersRsp {
@@ -153,11 +156,13 @@ func (o *GetV1beta1ClustersClusterIDSQLUsersBadRequest) Code() int {
 }
 
 func (o *GetV1beta1ClustersClusterIDSQLUsersBadRequest) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/sqlUsers][%d] getV1beta1ClustersClusterIdSqlUsersBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/sqlUsers][%d] getV1beta1ClustersClusterIdSqlUsersBadRequest %s", 400, payload)
 }
 
 func (o *GetV1beta1ClustersClusterIDSQLUsersBadRequest) String() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/sqlUsers][%d] getV1beta1ClustersClusterIdSqlUsersBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/sqlUsers][%d] getV1beta1ClustersClusterIdSqlUsersBadRequest %s", 400, payload)
 }
 
 func (o *GetV1beta1ClustersClusterIDSQLUsersBadRequest) GetPayload() *models.APIOpenAPIError {

--- a/pkg/tidbcloud/v1beta1/iam/client/account/get_v1beta1_clusters_cluster_id_sql_users_user_name_responses.go
+++ b/pkg/tidbcloud/v1beta1/iam/client/account/get_v1beta1_clusters_cluster_id_sql_users_user_name_responses.go
@@ -6,6 +6,7 @@ package account
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -85,11 +86,13 @@ func (o *GetV1beta1ClustersClusterIDSQLUsersUserNameOK) Code() int {
 }
 
 func (o *GetV1beta1ClustersClusterIDSQLUsersUserNameOK) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] getV1beta1ClustersClusterIdSqlUsersUserNameOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] getV1beta1ClustersClusterIdSqlUsersUserNameOK %s", 200, payload)
 }
 
 func (o *GetV1beta1ClustersClusterIDSQLUsersUserNameOK) String() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] getV1beta1ClustersClusterIdSqlUsersUserNameOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] getV1beta1ClustersClusterIdSqlUsersUserNameOK %s", 200, payload)
 }
 
 func (o *GetV1beta1ClustersClusterIDSQLUsersUserNameOK) GetPayload() *models.APISQLUser {
@@ -153,11 +156,13 @@ func (o *GetV1beta1ClustersClusterIDSQLUsersUserNameBadRequest) Code() int {
 }
 
 func (o *GetV1beta1ClustersClusterIDSQLUsersUserNameBadRequest) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] getV1beta1ClustersClusterIdSqlUsersUserNameBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] getV1beta1ClustersClusterIdSqlUsersUserNameBadRequest %s", 400, payload)
 }
 
 func (o *GetV1beta1ClustersClusterIDSQLUsersUserNameBadRequest) String() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] getV1beta1ClustersClusterIdSqlUsersUserNameBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] getV1beta1ClustersClusterIdSqlUsersUserNameBadRequest %s", 400, payload)
 }
 
 func (o *GetV1beta1ClustersClusterIDSQLUsersUserNameBadRequest) GetPayload() *models.APIOpenAPIError {

--- a/pkg/tidbcloud/v1beta1/iam/client/account/get_v1beta1_projects_responses.go
+++ b/pkg/tidbcloud/v1beta1/iam/client/account/get_v1beta1_projects_responses.go
@@ -6,6 +6,7 @@ package account
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -85,11 +86,13 @@ func (o *GetV1beta1ProjectsOK) Code() int {
 }
 
 func (o *GetV1beta1ProjectsOK) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/projects][%d] getV1beta1ProjectsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/projects][%d] getV1beta1ProjectsOK %s", 200, payload)
 }
 
 func (o *GetV1beta1ProjectsOK) String() string {
-	return fmt.Sprintf("[GET /v1beta1/projects][%d] getV1beta1ProjectsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/projects][%d] getV1beta1ProjectsOK %s", 200, payload)
 }
 
 func (o *GetV1beta1ProjectsOK) GetPayload() *models.APIListProjectsRsp {
@@ -153,11 +156,13 @@ func (o *GetV1beta1ProjectsBadRequest) Code() int {
 }
 
 func (o *GetV1beta1ProjectsBadRequest) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/projects][%d] getV1beta1ProjectsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/projects][%d] getV1beta1ProjectsBadRequest %s", 400, payload)
 }
 
 func (o *GetV1beta1ProjectsBadRequest) String() string {
-	return fmt.Sprintf("[GET /v1beta1/projects][%d] getV1beta1ProjectsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/projects][%d] getV1beta1ProjectsBadRequest %s", 400, payload)
 }
 
 func (o *GetV1beta1ProjectsBadRequest) GetPayload() *models.APIOpenAPIError {

--- a/pkg/tidbcloud/v1beta1/iam/client/account/patch_v1beta1_clusters_cluster_id_sql_users_user_name_responses.go
+++ b/pkg/tidbcloud/v1beta1/iam/client/account/patch_v1beta1_clusters_cluster_id_sql_users_user_name_responses.go
@@ -6,6 +6,7 @@ package account
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -85,11 +86,13 @@ func (o *PatchV1beta1ClustersClusterIDSQLUsersUserNameOK) Code() int {
 }
 
 func (o *PatchV1beta1ClustersClusterIDSQLUsersUserNameOK) Error() string {
-	return fmt.Sprintf("[PATCH /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] patchV1beta1ClustersClusterIdSqlUsersUserNameOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] patchV1beta1ClustersClusterIdSqlUsersUserNameOK %s", 200, payload)
 }
 
 func (o *PatchV1beta1ClustersClusterIDSQLUsersUserNameOK) String() string {
-	return fmt.Sprintf("[PATCH /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] patchV1beta1ClustersClusterIdSqlUsersUserNameOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] patchV1beta1ClustersClusterIdSqlUsersUserNameOK %s", 200, payload)
 }
 
 func (o *PatchV1beta1ClustersClusterIDSQLUsersUserNameOK) GetPayload() *models.APISQLUser {
@@ -153,11 +156,13 @@ func (o *PatchV1beta1ClustersClusterIDSQLUsersUserNameBadRequest) Code() int {
 }
 
 func (o *PatchV1beta1ClustersClusterIDSQLUsersUserNameBadRequest) Error() string {
-	return fmt.Sprintf("[PATCH /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] patchV1beta1ClustersClusterIdSqlUsersUserNameBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] patchV1beta1ClustersClusterIdSqlUsersUserNameBadRequest %s", 400, payload)
 }
 
 func (o *PatchV1beta1ClustersClusterIDSQLUsersUserNameBadRequest) String() string {
-	return fmt.Sprintf("[PATCH /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] patchV1beta1ClustersClusterIdSqlUsersUserNameBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /v1beta1/clusters/{clusterId}/sqlUsers/{userName}][%d] patchV1beta1ClustersClusterIdSqlUsersUserNameBadRequest %s", 400, payload)
 }
 
 func (o *PatchV1beta1ClustersClusterIDSQLUsersUserNameBadRequest) GetPayload() *models.APIOpenAPIError {

--- a/pkg/tidbcloud/v1beta1/iam/client/account/post_customer_signup_url_responses.go
+++ b/pkg/tidbcloud/v1beta1/iam/client/account/post_customer_signup_url_responses.go
@@ -6,6 +6,7 @@ package account
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -85,11 +86,13 @@ func (o *PostCustomerSignupURLOK) Code() int {
 }
 
 func (o *PostCustomerSignupURLOK) Error() string {
-	return fmt.Sprintf("[POST /customerSignupUrl][%d] postCustomerSignupUrlOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /customerSignupUrl][%d] postCustomerSignupUrlOK %s", 200, payload)
 }
 
 func (o *PostCustomerSignupURLOK) String() string {
-	return fmt.Sprintf("[POST /customerSignupUrl][%d] postCustomerSignupUrlOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /customerSignupUrl][%d] postCustomerSignupUrlOK %s", 200, payload)
 }
 
 func (o *PostCustomerSignupURLOK) GetPayload() *models.APIOpenAPIMspCustomerSignupURL {
@@ -153,11 +156,13 @@ func (o *PostCustomerSignupURLBadRequest) Code() int {
 }
 
 func (o *PostCustomerSignupURLBadRequest) Error() string {
-	return fmt.Sprintf("[POST /customerSignupUrl][%d] postCustomerSignupUrlBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /customerSignupUrl][%d] postCustomerSignupUrlBadRequest %s", 400, payload)
 }
 
 func (o *PostCustomerSignupURLBadRequest) String() string {
-	return fmt.Sprintf("[POST /customerSignupUrl][%d] postCustomerSignupUrlBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /customerSignupUrl][%d] postCustomerSignupUrlBadRequest %s", 400, payload)
 }
 
 func (o *PostCustomerSignupURLBadRequest) GetPayload() *models.APIOpenAPIError {

--- a/pkg/tidbcloud/v1beta1/iam/client/account/post_v1beta1_clusters_cluster_id_sql_users_responses.go
+++ b/pkg/tidbcloud/v1beta1/iam/client/account/post_v1beta1_clusters_cluster_id_sql_users_responses.go
@@ -6,6 +6,7 @@ package account
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -85,11 +86,13 @@ func (o *PostV1beta1ClustersClusterIDSQLUsersOK) Code() int {
 }
 
 func (o *PostV1beta1ClustersClusterIDSQLUsersOK) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/sqlUsers][%d] postV1beta1ClustersClusterIdSqlUsersOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/sqlUsers][%d] postV1beta1ClustersClusterIdSqlUsersOK %s", 200, payload)
 }
 
 func (o *PostV1beta1ClustersClusterIDSQLUsersOK) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/sqlUsers][%d] postV1beta1ClustersClusterIdSqlUsersOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/sqlUsers][%d] postV1beta1ClustersClusterIdSqlUsersOK %s", 200, payload)
 }
 
 func (o *PostV1beta1ClustersClusterIDSQLUsersOK) GetPayload() *models.APISQLUser {
@@ -153,11 +156,13 @@ func (o *PostV1beta1ClustersClusterIDSQLUsersBadRequest) Code() int {
 }
 
 func (o *PostV1beta1ClustersClusterIDSQLUsersBadRequest) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/sqlUsers][%d] postV1beta1ClustersClusterIdSqlUsersBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/sqlUsers][%d] postV1beta1ClustersClusterIdSqlUsersBadRequest %s", 400, payload)
 }
 
 func (o *PostV1beta1ClustersClusterIDSQLUsersBadRequest) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/sqlUsers][%d] postV1beta1ClustersClusterIdSqlUsersBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/sqlUsers][%d] postV1beta1ClustersClusterIdSqlUsersBadRequest %s", 400, payload)
 }
 
 func (o *PostV1beta1ClustersClusterIDSQLUsersBadRequest) GetPayload() *models.APIOpenAPIError {

--- a/pkg/tidbcloud/v1beta1/serverless/client/serverless_service/serverless_service_change_root_password_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless/client/serverless_service/serverless_service_change_root_password_responses.go
@@ -7,6 +7,7 @@ package serverless_service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -90,11 +91,13 @@ func (o *ServerlessServiceChangeRootPasswordOK) Code() int {
 }
 
 func (o *ServerlessServiceChangeRootPasswordOK) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{clusterId}/password][%d] serverlessServiceChangeRootPasswordOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /clusters/{clusterId}/password][%d] serverlessServiceChangeRootPasswordOK %s", 200, payload)
 }
 
 func (o *ServerlessServiceChangeRootPasswordOK) String() string {
-	return fmt.Sprintf("[PUT /clusters/{clusterId}/password][%d] serverlessServiceChangeRootPasswordOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /clusters/{clusterId}/password][%d] serverlessServiceChangeRootPasswordOK %s", 200, payload)
 }
 
 func (o *ServerlessServiceChangeRootPasswordOK) GetPayload() models.V1beta1ChangeRootPasswordResponse {
@@ -160,11 +163,13 @@ func (o *ServerlessServiceChangeRootPasswordDefault) Code() int {
 }
 
 func (o *ServerlessServiceChangeRootPasswordDefault) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{clusterId}/password][%d] ServerlessService_ChangeRootPassword default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /clusters/{clusterId}/password][%d] ServerlessService_ChangeRootPassword default %s", o._statusCode, payload)
 }
 
 func (o *ServerlessServiceChangeRootPasswordDefault) String() string {
-	return fmt.Sprintf("[PUT /clusters/{clusterId}/password][%d] ServerlessService_ChangeRootPassword default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /clusters/{clusterId}/password][%d] ServerlessService_ChangeRootPassword default %s", o._statusCode, payload)
 }
 
 func (o *ServerlessServiceChangeRootPasswordDefault) GetPayload() *models.GooglerpcStatus {

--- a/pkg/tidbcloud/v1beta1/serverless/client/serverless_service/serverless_service_client.go
+++ b/pkg/tidbcloud/v1beta1/serverless/client/serverless_service/serverless_service_client.go
@@ -7,12 +7,38 @@ package serverless_service
 
 import (
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new serverless service API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new serverless service API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new serverless service API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -23,7 +49,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/pkg/tidbcloud/v1beta1/serverless/client/serverless_service/serverless_service_create_cluster_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless/client/serverless_service/serverless_service_create_cluster_responses.go
@@ -6,6 +6,7 @@ package serverless_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ServerlessServiceCreateClusterOK) Code() int {
 }
 
 func (o *ServerlessServiceCreateClusterOK) Error() string {
-	return fmt.Sprintf("[POST /clusters][%d] serverlessServiceCreateClusterOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /clusters][%d] serverlessServiceCreateClusterOK %s", 200, payload)
 }
 
 func (o *ServerlessServiceCreateClusterOK) String() string {
-	return fmt.Sprintf("[POST /clusters][%d] serverlessServiceCreateClusterOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /clusters][%d] serverlessServiceCreateClusterOK %s", 200, payload)
 }
 
 func (o *ServerlessServiceCreateClusterOK) GetPayload() *models.TidbCloudOpenApiserverlessv1beta1Cluster {
@@ -158,11 +161,13 @@ func (o *ServerlessServiceCreateClusterDefault) Code() int {
 }
 
 func (o *ServerlessServiceCreateClusterDefault) Error() string {
-	return fmt.Sprintf("[POST /clusters][%d] ServerlessService_CreateCluster default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /clusters][%d] ServerlessService_CreateCluster default %s", o._statusCode, payload)
 }
 
 func (o *ServerlessServiceCreateClusterDefault) String() string {
-	return fmt.Sprintf("[POST /clusters][%d] ServerlessService_CreateCluster default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /clusters][%d] ServerlessService_CreateCluster default %s", o._statusCode, payload)
 }
 
 func (o *ServerlessServiceCreateClusterDefault) GetPayload() *models.GooglerpcStatus {

--- a/pkg/tidbcloud/v1beta1/serverless/client/serverless_service/serverless_service_delete_cluster_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless/client/serverless_service/serverless_service_delete_cluster_responses.go
@@ -6,6 +6,7 @@ package serverless_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ServerlessServiceDeleteClusterOK) Code() int {
 }
 
 func (o *ServerlessServiceDeleteClusterOK) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{clusterId}][%d] serverlessServiceDeleteClusterOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /clusters/{clusterId}][%d] serverlessServiceDeleteClusterOK %s", 200, payload)
 }
 
 func (o *ServerlessServiceDeleteClusterOK) String() string {
-	return fmt.Sprintf("[DELETE /clusters/{clusterId}][%d] serverlessServiceDeleteClusterOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /clusters/{clusterId}][%d] serverlessServiceDeleteClusterOK %s", 200, payload)
 }
 
 func (o *ServerlessServiceDeleteClusterOK) GetPayload() *models.TidbCloudOpenApiserverlessv1beta1Cluster {
@@ -158,11 +161,13 @@ func (o *ServerlessServiceDeleteClusterDefault) Code() int {
 }
 
 func (o *ServerlessServiceDeleteClusterDefault) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{clusterId}][%d] ServerlessService_DeleteCluster default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /clusters/{clusterId}][%d] ServerlessService_DeleteCluster default %s", o._statusCode, payload)
 }
 
 func (o *ServerlessServiceDeleteClusterDefault) String() string {
-	return fmt.Sprintf("[DELETE /clusters/{clusterId}][%d] ServerlessService_DeleteCluster default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /clusters/{clusterId}][%d] ServerlessService_DeleteCluster default %s", o._statusCode, payload)
 }
 
 func (o *ServerlessServiceDeleteClusterDefault) GetPayload() *models.GooglerpcStatus {

--- a/pkg/tidbcloud/v1beta1/serverless/client/serverless_service/serverless_service_get_cluster_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless/client/serverless_service/serverless_service_get_cluster_responses.go
@@ -6,6 +6,7 @@ package serverless_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ServerlessServiceGetClusterOK) Code() int {
 }
 
 func (o *ServerlessServiceGetClusterOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{clusterId}][%d] serverlessServiceGetClusterOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /clusters/{clusterId}][%d] serverlessServiceGetClusterOK %s", 200, payload)
 }
 
 func (o *ServerlessServiceGetClusterOK) String() string {
-	return fmt.Sprintf("[GET /clusters/{clusterId}][%d] serverlessServiceGetClusterOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /clusters/{clusterId}][%d] serverlessServiceGetClusterOK %s", 200, payload)
 }
 
 func (o *ServerlessServiceGetClusterOK) GetPayload() *models.TidbCloudOpenApiserverlessv1beta1Cluster {
@@ -158,11 +161,13 @@ func (o *ServerlessServiceGetClusterDefault) Code() int {
 }
 
 func (o *ServerlessServiceGetClusterDefault) Error() string {
-	return fmt.Sprintf("[GET /clusters/{clusterId}][%d] ServerlessService_GetCluster default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /clusters/{clusterId}][%d] ServerlessService_GetCluster default %s", o._statusCode, payload)
 }
 
 func (o *ServerlessServiceGetClusterDefault) String() string {
-	return fmt.Sprintf("[GET /clusters/{clusterId}][%d] ServerlessService_GetCluster default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /clusters/{clusterId}][%d] ServerlessService_GetCluster default %s", o._statusCode, payload)
 }
 
 func (o *ServerlessServiceGetClusterDefault) GetPayload() *models.GooglerpcStatus {

--- a/pkg/tidbcloud/v1beta1/serverless/client/serverless_service/serverless_service_list_clusters_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless/client/serverless_service/serverless_service_list_clusters_responses.go
@@ -6,6 +6,7 @@ package serverless_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ServerlessServiceListClustersOK) Code() int {
 }
 
 func (o *ServerlessServiceListClustersOK) Error() string {
-	return fmt.Sprintf("[GET /clusters][%d] serverlessServiceListClustersOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /clusters][%d] serverlessServiceListClustersOK %s", 200, payload)
 }
 
 func (o *ServerlessServiceListClustersOK) String() string {
-	return fmt.Sprintf("[GET /clusters][%d] serverlessServiceListClustersOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /clusters][%d] serverlessServiceListClustersOK %s", 200, payload)
 }
 
 func (o *ServerlessServiceListClustersOK) GetPayload() *models.TidbCloudOpenApiserverlessv1beta1ListClustersResponse {
@@ -158,11 +161,13 @@ func (o *ServerlessServiceListClustersDefault) Code() int {
 }
 
 func (o *ServerlessServiceListClustersDefault) Error() string {
-	return fmt.Sprintf("[GET /clusters][%d] ServerlessService_ListClusters default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /clusters][%d] ServerlessService_ListClusters default %s", o._statusCode, payload)
 }
 
 func (o *ServerlessServiceListClustersDefault) String() string {
-	return fmt.Sprintf("[GET /clusters][%d] ServerlessService_ListClusters default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /clusters][%d] ServerlessService_ListClusters default %s", o._statusCode, payload)
 }
 
 func (o *ServerlessServiceListClustersDefault) GetPayload() *models.GooglerpcStatus {

--- a/pkg/tidbcloud/v1beta1/serverless/client/serverless_service/serverless_service_list_regions_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless/client/serverless_service/serverless_service_list_regions_responses.go
@@ -6,6 +6,7 @@ package serverless_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ServerlessServiceListRegionsOK) Code() int {
 }
 
 func (o *ServerlessServiceListRegionsOK) Error() string {
-	return fmt.Sprintf("[GET /regions][%d] serverlessServiceListRegionsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /regions][%d] serverlessServiceListRegionsOK %s", 200, payload)
 }
 
 func (o *ServerlessServiceListRegionsOK) String() string {
-	return fmt.Sprintf("[GET /regions][%d] serverlessServiceListRegionsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /regions][%d] serverlessServiceListRegionsOK %s", 200, payload)
 }
 
 func (o *ServerlessServiceListRegionsOK) GetPayload() *models.TidbCloudOpenApiserverlessv1beta1ListRegionsResponse {
@@ -158,11 +161,13 @@ func (o *ServerlessServiceListRegionsDefault) Code() int {
 }
 
 func (o *ServerlessServiceListRegionsDefault) Error() string {
-	return fmt.Sprintf("[GET /regions][%d] ServerlessService_ListRegions default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /regions][%d] ServerlessService_ListRegions default %s", o._statusCode, payload)
 }
 
 func (o *ServerlessServiceListRegionsDefault) String() string {
-	return fmt.Sprintf("[GET /regions][%d] ServerlessService_ListRegions default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /regions][%d] ServerlessService_ListRegions default %s", o._statusCode, payload)
 }
 
 func (o *ServerlessServiceListRegionsDefault) GetPayload() *models.GooglerpcStatus {

--- a/pkg/tidbcloud/v1beta1/serverless/client/serverless_service/serverless_service_partial_update_cluster_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless/client/serverless_service/serverless_service_partial_update_cluster_responses.go
@@ -7,6 +7,7 @@ package serverless_service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -90,11 +91,13 @@ func (o *ServerlessServicePartialUpdateClusterOK) Code() int {
 }
 
 func (o *ServerlessServicePartialUpdateClusterOK) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster.clusterId}][%d] serverlessServicePartialUpdateClusterOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /clusters/{cluster.clusterId}][%d] serverlessServicePartialUpdateClusterOK %s", 200, payload)
 }
 
 func (o *ServerlessServicePartialUpdateClusterOK) String() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster.clusterId}][%d] serverlessServicePartialUpdateClusterOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /clusters/{cluster.clusterId}][%d] serverlessServicePartialUpdateClusterOK %s", 200, payload)
 }
 
 func (o *ServerlessServicePartialUpdateClusterOK) GetPayload() *models.TidbCloudOpenApiserverlessv1beta1Cluster {
@@ -162,11 +165,13 @@ func (o *ServerlessServicePartialUpdateClusterDefault) Code() int {
 }
 
 func (o *ServerlessServicePartialUpdateClusterDefault) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster.clusterId}][%d] ServerlessService_PartialUpdateCluster default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /clusters/{cluster.clusterId}][%d] ServerlessService_PartialUpdateCluster default %s", o._statusCode, payload)
 }
 
 func (o *ServerlessServicePartialUpdateClusterDefault) String() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster.clusterId}][%d] ServerlessService_PartialUpdateCluster default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /clusters/{cluster.clusterId}][%d] ServerlessService_PartialUpdateCluster default %s", o._statusCode, payload)
 }
 
 func (o *ServerlessServicePartialUpdateClusterDefault) GetPayload() *models.GooglerpcStatus {

--- a/pkg/tidbcloud/v1beta1/serverless/models/protobuf_any.go
+++ b/pkg/tidbcloud/v1beta1/serverless/models/protobuf_any.go
@@ -7,6 +7,7 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -19,6 +20,82 @@ type ProtobufAny struct {
 
 	// at type
 	AtType string `json:"@type,omitempty"`
+
+	// protobuf any
+	ProtobufAny map[string]interface{} `json:"-"`
+}
+
+// UnmarshalJSON unmarshals this object with additional properties from JSON
+func (m *ProtobufAny) UnmarshalJSON(data []byte) error {
+	// stage 1, bind the properties
+	var stage1 struct {
+
+		// at type
+		AtType string `json:"@type,omitempty"`
+	}
+	if err := json.Unmarshal(data, &stage1); err != nil {
+		return err
+	}
+	var rcv ProtobufAny
+
+	rcv.AtType = stage1.AtType
+	*m = rcv
+
+	// stage 2, remove properties and add to map
+	stage2 := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(data, &stage2); err != nil {
+		return err
+	}
+
+	delete(stage2, "@type")
+	// stage 3, add additional properties values
+	if len(stage2) > 0 {
+		result := make(map[string]interface{})
+		for k, v := range stage2 {
+			var toadd interface{}
+			if err := json.Unmarshal(v, &toadd); err != nil {
+				return err
+			}
+			result[k] = toadd
+		}
+		m.ProtobufAny = result
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals this object with additional properties into a JSON object
+func (m ProtobufAny) MarshalJSON() ([]byte, error) {
+	var stage1 struct {
+
+		// at type
+		AtType string `json:"@type,omitempty"`
+	}
+
+	stage1.AtType = m.AtType
+
+	// make JSON object for known properties
+	props, err := json.Marshal(stage1)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(m.ProtobufAny) == 0 { // no additional properties
+		return props, nil
+	}
+
+	// make JSON object for the additional properties
+	additional, err := json.Marshal(m.ProtobufAny)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(props) < 3 { // "{}": only additional properties
+		return additional, nil
+	}
+
+	// concatenate the 2 objects
+	return swag.ConcatJSON(props, additional), nil
 }
 
 // Validate validates this protobuf any

--- a/pkg/tidbcloud/v1beta1/serverless_br/client/backup_restore_service/backup_restore_service_client.go
+++ b/pkg/tidbcloud/v1beta1/serverless_br/client/backup_restore_service/backup_restore_service_client.go
@@ -7,12 +7,38 @@ package backup_restore_service
 
 import (
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new backup restore service API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new backup restore service API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new backup restore service API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -23,7 +49,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/pkg/tidbcloud/v1beta1/serverless_br/client/backup_restore_service/backup_restore_service_delete_backup_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless_br/client/backup_restore_service/backup_restore_service_delete_backup_responses.go
@@ -6,6 +6,7 @@ package backup_restore_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *BackupRestoreServiceDeleteBackupOK) Code() int {
 }
 
 func (o *BackupRestoreServiceDeleteBackupOK) Error() string {
-	return fmt.Sprintf("[DELETE /v1beta1/backups/{backupId}][%d] backupRestoreServiceDeleteBackupOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /v1beta1/backups/{backupId}][%d] backupRestoreServiceDeleteBackupOK %s", 200, payload)
 }
 
 func (o *BackupRestoreServiceDeleteBackupOK) String() string {
-	return fmt.Sprintf("[DELETE /v1beta1/backups/{backupId}][%d] backupRestoreServiceDeleteBackupOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /v1beta1/backups/{backupId}][%d] backupRestoreServiceDeleteBackupOK %s", 200, payload)
 }
 
 func (o *BackupRestoreServiceDeleteBackupOK) GetPayload() *models.V1beta1Backup {
@@ -158,11 +161,13 @@ func (o *BackupRestoreServiceDeleteBackupDefault) Code() int {
 }
 
 func (o *BackupRestoreServiceDeleteBackupDefault) Error() string {
-	return fmt.Sprintf("[DELETE /v1beta1/backups/{backupId}][%d] BackupRestoreService_DeleteBackup default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /v1beta1/backups/{backupId}][%d] BackupRestoreService_DeleteBackup default %s", o._statusCode, payload)
 }
 
 func (o *BackupRestoreServiceDeleteBackupDefault) String() string {
-	return fmt.Sprintf("[DELETE /v1beta1/backups/{backupId}][%d] BackupRestoreService_DeleteBackup default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /v1beta1/backups/{backupId}][%d] BackupRestoreService_DeleteBackup default %s", o._statusCode, payload)
 }
 
 func (o *BackupRestoreServiceDeleteBackupDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/serverless_br/client/backup_restore_service/backup_restore_service_get_backup_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless_br/client/backup_restore_service/backup_restore_service_get_backup_responses.go
@@ -6,6 +6,7 @@ package backup_restore_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *BackupRestoreServiceGetBackupOK) Code() int {
 }
 
 func (o *BackupRestoreServiceGetBackupOK) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/backups/{backupId}][%d] backupRestoreServiceGetBackupOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/backups/{backupId}][%d] backupRestoreServiceGetBackupOK %s", 200, payload)
 }
 
 func (o *BackupRestoreServiceGetBackupOK) String() string {
-	return fmt.Sprintf("[GET /v1beta1/backups/{backupId}][%d] backupRestoreServiceGetBackupOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/backups/{backupId}][%d] backupRestoreServiceGetBackupOK %s", 200, payload)
 }
 
 func (o *BackupRestoreServiceGetBackupOK) GetPayload() *models.V1beta1Backup {
@@ -158,11 +161,13 @@ func (o *BackupRestoreServiceGetBackupDefault) Code() int {
 }
 
 func (o *BackupRestoreServiceGetBackupDefault) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/backups/{backupId}][%d] BackupRestoreService_GetBackup default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/backups/{backupId}][%d] BackupRestoreService_GetBackup default %s", o._statusCode, payload)
 }
 
 func (o *BackupRestoreServiceGetBackupDefault) String() string {
-	return fmt.Sprintf("[GET /v1beta1/backups/{backupId}][%d] BackupRestoreService_GetBackup default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/backups/{backupId}][%d] BackupRestoreService_GetBackup default %s", o._statusCode, payload)
 }
 
 func (o *BackupRestoreServiceGetBackupDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/serverless_br/client/backup_restore_service/backup_restore_service_list_backups_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless_br/client/backup_restore_service/backup_restore_service_list_backups_responses.go
@@ -6,6 +6,7 @@ package backup_restore_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *BackupRestoreServiceListBackupsOK) Code() int {
 }
 
 func (o *BackupRestoreServiceListBackupsOK) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/backups][%d] backupRestoreServiceListBackupsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/backups][%d] backupRestoreServiceListBackupsOK %s", 200, payload)
 }
 
 func (o *BackupRestoreServiceListBackupsOK) String() string {
-	return fmt.Sprintf("[GET /v1beta1/backups][%d] backupRestoreServiceListBackupsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/backups][%d] backupRestoreServiceListBackupsOK %s", 200, payload)
 }
 
 func (o *BackupRestoreServiceListBackupsOK) GetPayload() *models.V1beta1ListBackupsResponse {
@@ -158,11 +161,13 @@ func (o *BackupRestoreServiceListBackupsDefault) Code() int {
 }
 
 func (o *BackupRestoreServiceListBackupsDefault) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/backups][%d] BackupRestoreService_ListBackups default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/backups][%d] BackupRestoreService_ListBackups default %s", o._statusCode, payload)
 }
 
 func (o *BackupRestoreServiceListBackupsDefault) String() string {
-	return fmt.Sprintf("[GET /v1beta1/backups][%d] BackupRestoreService_ListBackups default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/backups][%d] BackupRestoreService_ListBackups default %s", o._statusCode, payload)
 }
 
 func (o *BackupRestoreServiceListBackupsDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/serverless_br/client/backup_restore_service/backup_restore_service_restore_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless_br/client/backup_restore_service/backup_restore_service_restore_responses.go
@@ -6,6 +6,7 @@ package backup_restore_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *BackupRestoreServiceRestoreOK) Code() int {
 }
 
 func (o *BackupRestoreServiceRestoreOK) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters:restore][%d] backupRestoreServiceRestoreOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters:restore][%d] backupRestoreServiceRestoreOK %s", 200, payload)
 }
 
 func (o *BackupRestoreServiceRestoreOK) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters:restore][%d] backupRestoreServiceRestoreOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters:restore][%d] backupRestoreServiceRestoreOK %s", 200, payload)
 }
 
 func (o *BackupRestoreServiceRestoreOK) GetPayload() *models.V1beta1RestoreResponse {
@@ -158,11 +161,13 @@ func (o *BackupRestoreServiceRestoreDefault) Code() int {
 }
 
 func (o *BackupRestoreServiceRestoreDefault) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters:restore][%d] BackupRestoreService_Restore default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters:restore][%d] BackupRestoreService_Restore default %s", o._statusCode, payload)
 }
 
 func (o *BackupRestoreServiceRestoreDefault) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters:restore][%d] BackupRestoreService_Restore default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters:restore][%d] BackupRestoreService_Restore default %s", o._statusCode, payload)
 }
 
 func (o *BackupRestoreServiceRestoreDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/serverless_br/models/protobuf_any.go
+++ b/pkg/tidbcloud/v1beta1/serverless_br/models/protobuf_any.go
@@ -7,6 +7,7 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -19,6 +20,82 @@ type ProtobufAny struct {
 
 	// at type
 	AtType string `json:"@type,omitempty"`
+
+	// protobuf any
+	ProtobufAny map[string]interface{} `json:"-"`
+}
+
+// UnmarshalJSON unmarshals this object with additional properties from JSON
+func (m *ProtobufAny) UnmarshalJSON(data []byte) error {
+	// stage 1, bind the properties
+	var stage1 struct {
+
+		// at type
+		AtType string `json:"@type,omitempty"`
+	}
+	if err := json.Unmarshal(data, &stage1); err != nil {
+		return err
+	}
+	var rcv ProtobufAny
+
+	rcv.AtType = stage1.AtType
+	*m = rcv
+
+	// stage 2, remove properties and add to map
+	stage2 := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(data, &stage2); err != nil {
+		return err
+	}
+
+	delete(stage2, "@type")
+	// stage 3, add additional properties values
+	if len(stage2) > 0 {
+		result := make(map[string]interface{})
+		for k, v := range stage2 {
+			var toadd interface{}
+			if err := json.Unmarshal(v, &toadd); err != nil {
+				return err
+			}
+			result[k] = toadd
+		}
+		m.ProtobufAny = result
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals this object with additional properties into a JSON object
+func (m ProtobufAny) MarshalJSON() ([]byte, error) {
+	var stage1 struct {
+
+		// at type
+		AtType string `json:"@type,omitempty"`
+	}
+
+	stage1.AtType = m.AtType
+
+	// make JSON object for known properties
+	props, err := json.Marshal(stage1)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(m.ProtobufAny) == 0 { // no additional properties
+		return props, nil
+	}
+
+	// make JSON object for the additional properties
+	additional, err := json.Marshal(m.ProtobufAny)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(props) < 3 { // "{}": only additional properties
+		return additional, nil
+	}
+
+	// concatenate the 2 objects
+	return swag.ConcatJSON(props, additional), nil
 }
 
 // Validate validates this protobuf any

--- a/pkg/tidbcloud/v1beta1/serverless_export/client/export_service/export_service_cancel_export_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless_export/client/export_service/export_service_cancel_export_responses.go
@@ -6,6 +6,7 @@ package export_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ExportServiceCancelExportOK) Code() int {
 }
 
 func (o *ExportServiceCancelExportOK) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports/{exportId}:cancel][%d] exportServiceCancelExportOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports/{exportId}:cancel][%d] exportServiceCancelExportOK %s", 200, payload)
 }
 
 func (o *ExportServiceCancelExportOK) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports/{exportId}:cancel][%d] exportServiceCancelExportOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports/{exportId}:cancel][%d] exportServiceCancelExportOK %s", 200, payload)
 }
 
 func (o *ExportServiceCancelExportOK) GetPayload() *models.V1beta1Export {
@@ -158,11 +161,13 @@ func (o *ExportServiceCancelExportDefault) Code() int {
 }
 
 func (o *ExportServiceCancelExportDefault) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports/{exportId}:cancel][%d] ExportService_CancelExport default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports/{exportId}:cancel][%d] ExportService_CancelExport default %s", o._statusCode, payload)
 }
 
 func (o *ExportServiceCancelExportDefault) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports/{exportId}:cancel][%d] ExportService_CancelExport default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports/{exportId}:cancel][%d] ExportService_CancelExport default %s", o._statusCode, payload)
 }
 
 func (o *ExportServiceCancelExportDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/serverless_export/client/export_service/export_service_client.go
+++ b/pkg/tidbcloud/v1beta1/serverless_export/client/export_service/export_service_client.go
@@ -7,12 +7,38 @@ package export_service
 
 import (
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new export service API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new export service API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new export service API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -23,7 +49,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/pkg/tidbcloud/v1beta1/serverless_export/client/export_service/export_service_create_export_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless_export/client/export_service/export_service_create_export_responses.go
@@ -7,6 +7,7 @@ package export_service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -89,11 +90,13 @@ func (o *ExportServiceCreateExportOK) Code() int {
 }
 
 func (o *ExportServiceCreateExportOK) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports][%d] exportServiceCreateExportOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports][%d] exportServiceCreateExportOK %s", 200, payload)
 }
 
 func (o *ExportServiceCreateExportOK) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports][%d] exportServiceCreateExportOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports][%d] exportServiceCreateExportOK %s", 200, payload)
 }
 
 func (o *ExportServiceCreateExportOK) GetPayload() *models.V1beta1Export {
@@ -161,11 +164,13 @@ func (o *ExportServiceCreateExportDefault) Code() int {
 }
 
 func (o *ExportServiceCreateExportDefault) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports][%d] ExportService_CreateExport default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports][%d] ExportService_CreateExport default %s", o._statusCode, payload)
 }
 
 func (o *ExportServiceCreateExportDefault) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports][%d] ExportService_CreateExport default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports][%d] ExportService_CreateExport default %s", o._statusCode, payload)
 }
 
 func (o *ExportServiceCreateExportDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/serverless_export/client/export_service/export_service_delete_export_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless_export/client/export_service/export_service_delete_export_responses.go
@@ -6,6 +6,7 @@ package export_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ExportServiceDeleteExportOK) Code() int {
 }
 
 func (o *ExportServiceDeleteExportOK) Error() string {
-	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/exports/{exportId}][%d] exportServiceDeleteExportOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/exports/{exportId}][%d] exportServiceDeleteExportOK %s", 200, payload)
 }
 
 func (o *ExportServiceDeleteExportOK) String() string {
-	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/exports/{exportId}][%d] exportServiceDeleteExportOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/exports/{exportId}][%d] exportServiceDeleteExportOK %s", 200, payload)
 }
 
 func (o *ExportServiceDeleteExportOK) GetPayload() *models.V1beta1Export {
@@ -158,11 +161,13 @@ func (o *ExportServiceDeleteExportDefault) Code() int {
 }
 
 func (o *ExportServiceDeleteExportDefault) Error() string {
-	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/exports/{exportId}][%d] ExportService_DeleteExport default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/exports/{exportId}][%d] ExportService_DeleteExport default %s", o._statusCode, payload)
 }
 
 func (o *ExportServiceDeleteExportDefault) String() string {
-	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/exports/{exportId}][%d] ExportService_DeleteExport default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /v1beta1/clusters/{clusterId}/exports/{exportId}][%d] ExportService_DeleteExport default %s", o._statusCode, payload)
 }
 
 func (o *ExportServiceDeleteExportDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/serverless_export/client/export_service/export_service_download_export_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless_export/client/export_service/export_service_download_export_responses.go
@@ -6,6 +6,7 @@ package export_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ExportServiceDownloadExportOK) Code() int {
 }
 
 func (o *ExportServiceDownloadExportOK) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports/{exportId}:download][%d] exportServiceDownloadExportOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports/{exportId}:download][%d] exportServiceDownloadExportOK %s", 200, payload)
 }
 
 func (o *ExportServiceDownloadExportOK) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports/{exportId}:download][%d] exportServiceDownloadExportOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports/{exportId}:download][%d] exportServiceDownloadExportOK %s", 200, payload)
 }
 
 func (o *ExportServiceDownloadExportOK) GetPayload() *models.V1beta1DownloadExportsResponse {
@@ -158,11 +161,13 @@ func (o *ExportServiceDownloadExportDefault) Code() int {
 }
 
 func (o *ExportServiceDownloadExportDefault) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports/{exportId}:download][%d] ExportService_DownloadExport default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports/{exportId}:download][%d] ExportService_DownloadExport default %s", o._statusCode, payload)
 }
 
 func (o *ExportServiceDownloadExportDefault) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports/{exportId}:download][%d] ExportService_DownloadExport default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/exports/{exportId}:download][%d] ExportService_DownloadExport default %s", o._statusCode, payload)
 }
 
 func (o *ExportServiceDownloadExportDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/serverless_export/client/export_service/export_service_get_export_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless_export/client/export_service/export_service_get_export_responses.go
@@ -6,6 +6,7 @@ package export_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ExportServiceGetExportOK) Code() int {
 }
 
 func (o *ExportServiceGetExportOK) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/exports/{exportId}][%d] exportServiceGetExportOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/exports/{exportId}][%d] exportServiceGetExportOK %s", 200, payload)
 }
 
 func (o *ExportServiceGetExportOK) String() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/exports/{exportId}][%d] exportServiceGetExportOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/exports/{exportId}][%d] exportServiceGetExportOK %s", 200, payload)
 }
 
 func (o *ExportServiceGetExportOK) GetPayload() *models.V1beta1Export {
@@ -158,11 +161,13 @@ func (o *ExportServiceGetExportDefault) Code() int {
 }
 
 func (o *ExportServiceGetExportDefault) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/exports/{exportId}][%d] ExportService_GetExport default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/exports/{exportId}][%d] ExportService_GetExport default %s", o._statusCode, payload)
 }
 
 func (o *ExportServiceGetExportDefault) String() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/exports/{exportId}][%d] ExportService_GetExport default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/exports/{exportId}][%d] ExportService_GetExport default %s", o._statusCode, payload)
 }
 
 func (o *ExportServiceGetExportDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/serverless_export/client/export_service/export_service_list_exports_parameters.go
+++ b/pkg/tidbcloud/v1beta1/serverless_export/client/export_service/export_service_list_exports_parameters.go
@@ -68,6 +68,12 @@ type ExportServiceListExportsParams struct {
 	*/
 	ClusterID string
 
+	/* OrderBy.
+
+	   Optional. List exports order by, separated by comma, default is ascending. Example: "foo, bar desc". Supported filed: create_time
+	*/
+	OrderBy *string
+
 	/* PageSize.
 
 	   Optional. The maximum number of clusters to return.
@@ -146,6 +152,17 @@ func (o *ExportServiceListExportsParams) SetClusterID(clusterID string) {
 	o.ClusterID = clusterID
 }
 
+// WithOrderBy adds the orderBy to the export service list exports params
+func (o *ExportServiceListExportsParams) WithOrderBy(orderBy *string) *ExportServiceListExportsParams {
+	o.SetOrderBy(orderBy)
+	return o
+}
+
+// SetOrderBy adds the orderBy to the export service list exports params
+func (o *ExportServiceListExportsParams) SetOrderBy(orderBy *string) {
+	o.OrderBy = orderBy
+}
+
 // WithPageSize adds the pageSize to the export service list exports params
 func (o *ExportServiceListExportsParams) WithPageSize(pageSize *int32) *ExportServiceListExportsParams {
 	o.SetPageSize(pageSize)
@@ -179,6 +196,23 @@ func (o *ExportServiceListExportsParams) WriteToRequest(r runtime.ClientRequest,
 	// path param clusterId
 	if err := r.SetPathParam("clusterId", o.ClusterID); err != nil {
 		return err
+	}
+
+	if o.OrderBy != nil {
+
+		// query param orderBy
+		var qrOrderBy string
+
+		if o.OrderBy != nil {
+			qrOrderBy = *o.OrderBy
+		}
+		qOrderBy := qrOrderBy
+		if qOrderBy != "" {
+
+			if err := r.SetQueryParam("orderBy", qOrderBy); err != nil {
+				return err
+			}
+		}
 	}
 
 	if o.PageSize != nil {

--- a/pkg/tidbcloud/v1beta1/serverless_export/client/export_service/export_service_list_exports_parameters.go
+++ b/pkg/tidbcloud/v1beta1/serverless_export/client/export_service/export_service_list_exports_parameters.go
@@ -70,7 +70,7 @@ type ExportServiceListExportsParams struct {
 
 	/* OrderBy.
 
-	   Optional. List exports order by, separated by comma, default is ascending. Example: "foo, bar desc". Supported filed: create_time
+	   Optional. List exports order by, separated by comma, default is ascending. Example: "foo, bar desc". Supported field: create_time
 	*/
 	OrderBy *string
 

--- a/pkg/tidbcloud/v1beta1/serverless_export/client/export_service/export_service_list_exports_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless_export/client/export_service/export_service_list_exports_responses.go
@@ -6,6 +6,7 @@ package export_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ExportServiceListExportsOK) Code() int {
 }
 
 func (o *ExportServiceListExportsOK) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/exports][%d] exportServiceListExportsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/exports][%d] exportServiceListExportsOK %s", 200, payload)
 }
 
 func (o *ExportServiceListExportsOK) String() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/exports][%d] exportServiceListExportsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/exports][%d] exportServiceListExportsOK %s", 200, payload)
 }
 
 func (o *ExportServiceListExportsOK) GetPayload() *models.V1beta1ListExportsResponse {
@@ -158,11 +161,13 @@ func (o *ExportServiceListExportsDefault) Code() int {
 }
 
 func (o *ExportServiceListExportsDefault) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/exports][%d] ExportService_ListExports default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/exports][%d] ExportService_ListExports default %s", o._statusCode, payload)
 }
 
 func (o *ExportServiceListExportsDefault) String() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/exports][%d] ExportService_ListExports default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/exports][%d] ExportService_ListExports default %s", o._statusCode, payload)
 }
 
 func (o *ExportServiceListExportsDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/serverless_export/export.swagger.json
+++ b/pkg/tidbcloud/v1beta1/serverless_export/export.swagger.json
@@ -61,6 +61,13 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "description": "Optional. List exports order by, separated by comma, default is ascending. Example: \"foo, bar desc\". Supported filed: create_time",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "tags": [
@@ -307,7 +314,7 @@
         },
         "table": {
           "$ref": "#/definitions/FilterTable",
-          "description": "Optional. Use DBTable to filter the export."
+          "description": "Optional. Use table-filter to filter the export."
         }
       }
     },
@@ -319,11 +326,11 @@
           "items": {
             "type": "string"
           },
-          "description": "Optional. The table filter expressions."
+          "description": "Optional. The table-filter expressions."
         },
         "where": {
           "type": "string",
-          "description": "Optional. The specify table of the export."
+          "description": "Optional. Export only selected records."
         }
       }
     },
@@ -566,7 +573,7 @@
         "totalSize": {
           "type": "integer",
           "format": "int64",
-          "description": "Total number of backups."
+          "description": "Total number of exports."
         }
       }
     },

--- a/pkg/tidbcloud/v1beta1/serverless_export/export.swagger.json
+++ b/pkg/tidbcloud/v1beta1/serverless_export/export.swagger.json
@@ -64,7 +64,7 @@
           },
           {
             "name": "orderBy",
-            "description": "Optional. List exports order by, separated by comma, default is ascending. Example: \"foo, bar desc\". Supported filed: create_time",
+            "description": "Optional. List exports order by, separated by comma, default is ascending. Example: \"foo, bar desc\". Supported field: create_time",
             "in": "query",
             "required": false,
             "type": "string"

--- a/pkg/tidbcloud/v1beta1/serverless_export/models/export_options_filter.go
+++ b/pkg/tidbcloud/v1beta1/serverless_export/models/export_options_filter.go
@@ -21,7 +21,7 @@ type ExportOptionsFilter struct {
 	// Optional. Use SQL to filter the export.
 	SQL string `json:"sql,omitempty"`
 
-	// Optional. Use DBTable to filter the export.
+	// Optional. Use table-filter to filter the export.
 	Table *FilterTable `json:"table,omitempty"`
 }
 

--- a/pkg/tidbcloud/v1beta1/serverless_export/models/filter_table.go
+++ b/pkg/tidbcloud/v1beta1/serverless_export/models/filter_table.go
@@ -17,10 +17,10 @@ import (
 // swagger:model FilterTable
 type FilterTable struct {
 
-	// Optional. The table filter expressions.
+	// Optional. The table-filter expressions.
 	Patterns []string `json:"patterns"`
 
-	// Optional. The specify table of the export.
+	// Optional. Export only selected records.
 	Where string `json:"where,omitempty"`
 }
 

--- a/pkg/tidbcloud/v1beta1/serverless_export/models/protobuf_any.go
+++ b/pkg/tidbcloud/v1beta1/serverless_export/models/protobuf_any.go
@@ -7,6 +7,7 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -19,6 +20,82 @@ type ProtobufAny struct {
 
 	// at type
 	AtType string `json:"@type,omitempty"`
+
+	// protobuf any
+	ProtobufAny map[string]interface{} `json:"-"`
+}
+
+// UnmarshalJSON unmarshals this object with additional properties from JSON
+func (m *ProtobufAny) UnmarshalJSON(data []byte) error {
+	// stage 1, bind the properties
+	var stage1 struct {
+
+		// at type
+		AtType string `json:"@type,omitempty"`
+	}
+	if err := json.Unmarshal(data, &stage1); err != nil {
+		return err
+	}
+	var rcv ProtobufAny
+
+	rcv.AtType = stage1.AtType
+	*m = rcv
+
+	// stage 2, remove properties and add to map
+	stage2 := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(data, &stage2); err != nil {
+		return err
+	}
+
+	delete(stage2, "@type")
+	// stage 3, add additional properties values
+	if len(stage2) > 0 {
+		result := make(map[string]interface{})
+		for k, v := range stage2 {
+			var toadd interface{}
+			if err := json.Unmarshal(v, &toadd); err != nil {
+				return err
+			}
+			result[k] = toadd
+		}
+		m.ProtobufAny = result
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals this object with additional properties into a JSON object
+func (m ProtobufAny) MarshalJSON() ([]byte, error) {
+	var stage1 struct {
+
+		// at type
+		AtType string `json:"@type,omitempty"`
+	}
+
+	stage1.AtType = m.AtType
+
+	// make JSON object for known properties
+	props, err := json.Marshal(stage1)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(m.ProtobufAny) == 0 { // no additional properties
+		return props, nil
+	}
+
+	// make JSON object for the additional properties
+	additional, err := json.Marshal(m.ProtobufAny)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(props) < 3 { // "{}": only additional properties
+		return additional, nil
+	}
+
+	// concatenate the 2 objects
+	return swag.ConcatJSON(props, additional), nil
 }
 
 // Validate validates this protobuf any

--- a/pkg/tidbcloud/v1beta1/serverless_export/models/v1beta1_list_exports_response.go
+++ b/pkg/tidbcloud/v1beta1/serverless_export/models/v1beta1_list_exports_response.go
@@ -25,7 +25,7 @@ type V1beta1ListExportsResponse struct {
 	// Token provided to retrieve the next page of results.
 	NextPageToken string `json:"nextPageToken,omitempty"`
 
-	// Total number of backups.
+	// Total number of exports.
 	TotalSize int64 `json:"totalSize,omitempty"`
 }
 

--- a/pkg/tidbcloud/v1beta1/serverless_import/client/import_service/import_service_cancel_import_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless_import/client/import_service/import_service_cancel_import_responses.go
@@ -6,6 +6,7 @@ package import_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ImportServiceCancelImportOK) Code() int {
 }
 
 func (o *ImportServiceCancelImportOK) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports/{id}:cancel][%d] importServiceCancelImportOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports/{id}:cancel][%d] importServiceCancelImportOK %s", 200, payload)
 }
 
 func (o *ImportServiceCancelImportOK) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports/{id}:cancel][%d] importServiceCancelImportOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports/{id}:cancel][%d] importServiceCancelImportOK %s", 200, payload)
 }
 
 func (o *ImportServiceCancelImportOK) GetPayload() interface{} {
@@ -156,11 +159,13 @@ func (o *ImportServiceCancelImportDefault) Code() int {
 }
 
 func (o *ImportServiceCancelImportDefault) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports/{id}:cancel][%d] ImportService_CancelImport default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports/{id}:cancel][%d] ImportService_CancelImport default %s", o._statusCode, payload)
 }
 
 func (o *ImportServiceCancelImportDefault) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports/{id}:cancel][%d] ImportService_CancelImport default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports/{id}:cancel][%d] ImportService_CancelImport default %s", o._statusCode, payload)
 }
 
 func (o *ImportServiceCancelImportDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/serverless_import/client/import_service/import_service_cancel_upload_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless_import/client/import_service/import_service_cancel_upload_responses.go
@@ -6,6 +6,7 @@ package import_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ImportServiceCancelUploadOK) Code() int {
 }
 
 func (o *ImportServiceCancelUploadOK) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:cancelUpload][%d] importServiceCancelUploadOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:cancelUpload][%d] importServiceCancelUploadOK %s", 200, payload)
 }
 
 func (o *ImportServiceCancelUploadOK) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:cancelUpload][%d] importServiceCancelUploadOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:cancelUpload][%d] importServiceCancelUploadOK %s", 200, payload)
 }
 
 func (o *ImportServiceCancelUploadOK) GetPayload() interface{} {
@@ -156,11 +159,13 @@ func (o *ImportServiceCancelUploadDefault) Code() int {
 }
 
 func (o *ImportServiceCancelUploadDefault) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:cancelUpload][%d] ImportService_CancelUpload default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:cancelUpload][%d] ImportService_CancelUpload default %s", o._statusCode, payload)
 }
 
 func (o *ImportServiceCancelUploadDefault) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:cancelUpload][%d] ImportService_CancelUpload default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:cancelUpload][%d] ImportService_CancelUpload default %s", o._statusCode, payload)
 }
 
 func (o *ImportServiceCancelUploadDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/serverless_import/client/import_service/import_service_client.go
+++ b/pkg/tidbcloud/v1beta1/serverless_import/client/import_service/import_service_client.go
@@ -7,12 +7,38 @@ package import_service
 
 import (
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new import service API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new import service API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new import service API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -23,7 +49,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/pkg/tidbcloud/v1beta1/serverless_import/client/import_service/import_service_complete_upload_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless_import/client/import_service/import_service_complete_upload_responses.go
@@ -6,6 +6,7 @@ package import_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ImportServiceCompleteUploadOK) Code() int {
 }
 
 func (o *ImportServiceCompleteUploadOK) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:completeUpload][%d] importServiceCompleteUploadOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:completeUpload][%d] importServiceCompleteUploadOK %s", 200, payload)
 }
 
 func (o *ImportServiceCompleteUploadOK) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:completeUpload][%d] importServiceCompleteUploadOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:completeUpload][%d] importServiceCompleteUploadOK %s", 200, payload)
 }
 
 func (o *ImportServiceCompleteUploadOK) GetPayload() interface{} {
@@ -156,11 +159,13 @@ func (o *ImportServiceCompleteUploadDefault) Code() int {
 }
 
 func (o *ImportServiceCompleteUploadDefault) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:completeUpload][%d] ImportService_CompleteUpload default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:completeUpload][%d] ImportService_CompleteUpload default %s", o._statusCode, payload)
 }
 
 func (o *ImportServiceCompleteUploadDefault) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:completeUpload][%d] ImportService_CompleteUpload default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:completeUpload][%d] ImportService_CompleteUpload default %s", o._statusCode, payload)
 }
 
 func (o *ImportServiceCompleteUploadDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/serverless_import/client/import_service/import_service_create_import_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless_import/client/import_service/import_service_create_import_responses.go
@@ -7,6 +7,7 @@ package import_service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -90,11 +91,13 @@ func (o *ImportServiceCreateImportOK) Code() int {
 }
 
 func (o *ImportServiceCreateImportOK) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports][%d] importServiceCreateImportOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports][%d] importServiceCreateImportOK %s", 200, payload)
 }
 
 func (o *ImportServiceCreateImportOK) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports][%d] importServiceCreateImportOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports][%d] importServiceCreateImportOK %s", 200, payload)
 }
 
 func (o *ImportServiceCreateImportOK) GetPayload() *models.V1beta1Import {
@@ -162,11 +165,13 @@ func (o *ImportServiceCreateImportDefault) Code() int {
 }
 
 func (o *ImportServiceCreateImportDefault) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports][%d] ImportService_CreateImport default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports][%d] ImportService_CreateImport default %s", o._statusCode, payload)
 }
 
 func (o *ImportServiceCreateImportDefault) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports][%d] ImportService_CreateImport default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports][%d] ImportService_CreateImport default %s", o._statusCode, payload)
 }
 
 func (o *ImportServiceCreateImportDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/serverless_import/client/import_service/import_service_get_import_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless_import/client/import_service/import_service_get_import_responses.go
@@ -6,6 +6,7 @@ package import_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ImportServiceGetImportOK) Code() int {
 }
 
 func (o *ImportServiceGetImportOK) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/imports/{id}][%d] importServiceGetImportOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/imports/{id}][%d] importServiceGetImportOK %s", 200, payload)
 }
 
 func (o *ImportServiceGetImportOK) String() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/imports/{id}][%d] importServiceGetImportOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/imports/{id}][%d] importServiceGetImportOK %s", 200, payload)
 }
 
 func (o *ImportServiceGetImportOK) GetPayload() *models.V1beta1Import {
@@ -158,11 +161,13 @@ func (o *ImportServiceGetImportDefault) Code() int {
 }
 
 func (o *ImportServiceGetImportDefault) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/imports/{id}][%d] ImportService_GetImport default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/imports/{id}][%d] ImportService_GetImport default %s", o._statusCode, payload)
 }
 
 func (o *ImportServiceGetImportDefault) String() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/imports/{id}][%d] ImportService_GetImport default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/imports/{id}][%d] ImportService_GetImport default %s", o._statusCode, payload)
 }
 
 func (o *ImportServiceGetImportDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/serverless_import/client/import_service/import_service_list_imports_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless_import/client/import_service/import_service_list_imports_responses.go
@@ -6,6 +6,7 @@ package import_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ImportServiceListImportsOK) Code() int {
 }
 
 func (o *ImportServiceListImportsOK) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/imports][%d] importServiceListImportsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/imports][%d] importServiceListImportsOK %s", 200, payload)
 }
 
 func (o *ImportServiceListImportsOK) String() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/imports][%d] importServiceListImportsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/imports][%d] importServiceListImportsOK %s", 200, payload)
 }
 
 func (o *ImportServiceListImportsOK) GetPayload() *models.V1beta1ListImportsResp {
@@ -158,11 +161,13 @@ func (o *ImportServiceListImportsDefault) Code() int {
 }
 
 func (o *ImportServiceListImportsDefault) Error() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/imports][%d] ImportService_ListImports default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/imports][%d] ImportService_ListImports default %s", o._statusCode, payload)
 }
 
 func (o *ImportServiceListImportsDefault) String() string {
-	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/imports][%d] ImportService_ListImports default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1beta1/clusters/{clusterId}/imports][%d] ImportService_ListImports default %s", o._statusCode, payload)
 }
 
 func (o *ImportServiceListImportsDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/serverless_import/client/import_service/import_service_start_upload_responses.go
+++ b/pkg/tidbcloud/v1beta1/serverless_import/client/import_service/import_service_start_upload_responses.go
@@ -6,6 +6,7 @@ package import_service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ImportServiceStartUploadOK) Code() int {
 }
 
 func (o *ImportServiceStartUploadOK) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:startUpload][%d] importServiceStartUploadOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:startUpload][%d] importServiceStartUploadOK %s", 200, payload)
 }
 
 func (o *ImportServiceStartUploadOK) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:startUpload][%d] importServiceStartUploadOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:startUpload][%d] importServiceStartUploadOK %s", 200, payload)
 }
 
 func (o *ImportServiceStartUploadOK) GetPayload() *models.V1beta1StartUploadResponse {
@@ -158,11 +161,13 @@ func (o *ImportServiceStartUploadDefault) Code() int {
 }
 
 func (o *ImportServiceStartUploadDefault) Error() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:startUpload][%d] ImportService_StartUpload default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:startUpload][%d] ImportService_StartUpload default %s", o._statusCode, payload)
 }
 
 func (o *ImportServiceStartUploadDefault) String() string {
-	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:startUpload][%d] ImportService_StartUpload default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /v1beta1/clusters/{clusterId}/imports:startUpload][%d] ImportService_StartUpload default %s", o._statusCode, payload)
 }
 
 func (o *ImportServiceStartUploadDefault) GetPayload() *models.RPCStatus {

--- a/pkg/tidbcloud/v1beta1/serverless_import/models/protobuf_any.go
+++ b/pkg/tidbcloud/v1beta1/serverless_import/models/protobuf_any.go
@@ -7,6 +7,7 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -19,6 +20,82 @@ type ProtobufAny struct {
 
 	// at type
 	AtType string `json:"@type,omitempty"`
+
+	// protobuf any
+	ProtobufAny map[string]interface{} `json:"-"`
+}
+
+// UnmarshalJSON unmarshals this object with additional properties from JSON
+func (m *ProtobufAny) UnmarshalJSON(data []byte) error {
+	// stage 1, bind the properties
+	var stage1 struct {
+
+		// at type
+		AtType string `json:"@type,omitempty"`
+	}
+	if err := json.Unmarshal(data, &stage1); err != nil {
+		return err
+	}
+	var rcv ProtobufAny
+
+	rcv.AtType = stage1.AtType
+	*m = rcv
+
+	// stage 2, remove properties and add to map
+	stage2 := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(data, &stage2); err != nil {
+		return err
+	}
+
+	delete(stage2, "@type")
+	// stage 3, add additional properties values
+	if len(stage2) > 0 {
+		result := make(map[string]interface{})
+		for k, v := range stage2 {
+			var toadd interface{}
+			if err := json.Unmarshal(v, &toadd); err != nil {
+				return err
+			}
+			result[k] = toadd
+		}
+		m.ProtobufAny = result
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals this object with additional properties into a JSON object
+func (m ProtobufAny) MarshalJSON() ([]byte, error) {
+	var stage1 struct {
+
+		// at type
+		AtType string `json:"@type,omitempty"`
+	}
+
+	stage1.AtType = m.AtType
+
+	// make JSON object for known properties
+	props, err := json.Marshal(stage1)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(m.ProtobufAny) == 0 { // no additional properties
+		return props, nil
+	}
+
+	// make JSON object for the additional properties
+	additional, err := json.Marshal(m.ProtobufAny)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(props) < 3 { // "{}": only additional properties
+		return additional, nil
+	}
+
+	// concatenate the 2 objects
+	return swag.ConcatJSON(props, additional), nil
 }
 
 // Validate validates this protobuf any


### PR DESCRIPTION
## What is the purpose of the change

<!-- (For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).) -->

## Brief change log

<!-- *(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache* -->
