### PR TITLE
Update proto

### DIFF
--- a/internal/cli/serverless/branch/list.go
+++ b/internal/cli/serverless/branch/list.go
@@ -138,10 +138,10 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 				columns := []output.Column{
 					"ID",
 					"DisplayName",
+					"ParentID",
 					"ParentDisplayName",
 					"State",
 					"CreateTime",
-					"UpdateTime",
 				}
 
 				var rows []output.Row
@@ -149,10 +149,10 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 					rows = append(rows, output.Row{
 						item.BranchID,
 						*item.DisplayName,
+						item.ParentID,
 						item.ParentDisplayName,
 						string(item.State),
 						item.CreateTime.String(),
-						item.UpdateTime.String(),
 					})
 				}
 

--- a/internal/cli/serverless/create.go
+++ b/internal/cli/serverless/create.go
@@ -46,9 +46,8 @@ var createClusterField = map[string]int{
 }
 
 const (
-	serverlessType = "SERVERLESS"
-	WaitInterval   = 5 * time.Second
-	WaitTimeout    = 2 * time.Minute
+	WaitInterval = 5 * time.Second
+	WaitTimeout  = 2 * time.Minute
 )
 
 type CreateOpts struct {

--- a/internal/cli/serverless/list.go
+++ b/internal/cli/serverless/list.go
@@ -125,7 +125,7 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 					"Version",
 					"Cloud",
 					"Region",
-					"Type",
+					"CreateTime",
 				}
 
 				var rows []output.Row
@@ -137,7 +137,7 @@ func ListCmd(h *internal.Helper) *cobra.Command {
 						item.Version,
 						string(*item.Region.Provider),
 						item.Region.DisplayName,
-						serverlessType,
+						item.CreateTime.String(),
 					})
 				}
 

--- a/pkg/tidbcloud/v1beta1/branch/branch.swagger.json
+++ b/pkg/tidbcloud/v1beta1/branch/branch.swagger.json
@@ -384,12 +384,12 @@
         "endpoints": {
           "$ref": "#/definitions/BranchEndpoints",
           "x-nullable": true,
-          "description": "Optional. The endpoints of this branch. Only display in FULL view."
+          "description": "Optional. The endpoints of this branch."
         },
         "userPrefix": {
           "type": "string",
           "x-nullable": true,
-          "description": "Output only. User name prefix of this branch. Only display in FULL view. For each TiDB Serverless branch,\nTiDB Cloud generates a unique prefix to distinguish it from other branches.\nWhenever you use or set a database user name, you must include the prefix in the user name.",
+          "description": "Output only. User name prefix of this branch. For each TiDB Serverless branch,\nTiDB Cloud generates a unique prefix to distinguish it from other branches.\nWhenever you use or set a database user name, you must include the prefix in the user name.",
           "readOnly": true
         },
         "usage": {

--- a/pkg/tidbcloud/v1beta1/branch/models/v1beta1_branch.go
+++ b/pkg/tidbcloud/v1beta1/branch/models/v1beta1_branch.go
@@ -43,7 +43,7 @@ type V1beta1Branch struct {
 	// Required: true
 	DisplayName *string `json:"displayName"`
 
-	// Optional. The endpoints of this branch. Only display in FULL view.
+	// Optional. The endpoints of this branch.
 	Endpoints *BranchEndpoints `json:"endpoints,omitempty"`
 
 	// Output Only. The name of the resource.
@@ -68,7 +68,7 @@ type V1beta1Branch struct {
 	// OPTIONAL. Usage metrics of this branch. Only display in FULL view.
 	Usage *BranchUsage `json:"usage,omitempty"`
 
-	// Output only. User name prefix of this branch. Only display in FULL view. For each TiDB Serverless branch,
+	// Output only. User name prefix of this branch. For each TiDB Serverless branch,
 	// TiDB Cloud generates a unique prefix to distinguish it from other branches.
 	// Whenever you use or set a database user name, you must include the prefix in the user name.
 	// Read Only: true


### PR DESCRIPTION
## What is the purpose of the change

<!-- (For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).) -->

## Brief change log

<!-- *(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache* -->
