### PR TITLE
add nightly release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "nightly-*"
 
 jobs:
   goreleaser_and_TiUP:
@@ -72,8 +73,8 @@ jobs:
           )
           
           # check if the tag name is nightly
-          if [[ $REL_VER == *"-nightly"* ]]; then
-            export VER="nightly"
+          if [[ $REL_VER == "*nightly-*" ]]; then
+            export VER="${REL_VER}"
           else
           # skip the first letter v in the tag name
             export VER="${REL_VER:1}"
@@ -96,6 +97,7 @@ jobs:
             done
 
   create-pr:
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs: ["goreleaser_and_TiUP"]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           tar -zxf $TMP_DIR/tiup-linux-amd64.tar.gz -C $TIUP_HOME/bin && chmod 755 $TIUP_HOME/bin/tiup
           curl -s https://tiup-mirrors.pingcap.com/root.json -o $TIUP_HOME/bin/root.json
             
-          TIUP_MIRRORS=${{ secrets.TIUP_SERVER_PROD }}
+          TIUP_MIRRORS=${{ secrets.TIUP_SERVER_STAGING }}
           $TIUP_HOME/bin/tiup mirror set ${TIUP_MIRRORS}
           echo ${{ secrets.TIUP_COMP_KEY_PINGCAP }} | base64 -d > $TIUP_HOME/keys/private.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           )
           
           # check if the tag name is nightly
-          if [[ $REL_VER == "*nightly-*" ]]; then
+          if [[ "$REL_VER" == *nightly-* ]]; then
             export VER="${REL_VER}"
           else
           # skip the first letter v in the tag name

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,9 +71,13 @@ jobs:
             'linux arm64'
           )
           
+          # check if the tag name is nightly
+          if [[ $REL_VER == *"-nightly"* ]]; then
+            export VER="nightly"
+          else
           # skip the first letter v in the tag name
-          export VER="${REL_VER:1}"
-          
+            export VER="${REL_VER:1}"
+          fi
             for item in "${matrix[@]}" ; do
               os_arch=($item)
               os=(${os_arch[0]})

--- a/internal/cli/version/version.go
+++ b/internal/cli/version/version.go
@@ -41,11 +41,12 @@ func VersionCmd(h *internal.Helper) *cobra.Command {
 
 // Format formats a version string with the given information.
 func Format(ver, commit, buildDate string) string {
+	fmt.Println("ver:", ver)
 	if ver == version.DevVersion && buildDate == "" && commit == "" {
 		return fmt.Sprintf("%s version (built from source)", config.CliName)
 	}
 
-	if ver == version.NightlyVersion {
+	if strings.Contains(ver, version.NightlyVersion) {
 		return fmt.Sprintf("%s version %s-%s (commit: %s)\n", config.CliName, ver, buildDate, commit)
 	}
 

--- a/internal/cli/version/version.go
+++ b/internal/cli/version/version.go
@@ -45,6 +45,10 @@ func Format(ver, commit, buildDate string) string {
 		return fmt.Sprintf("%s version (built from source)", config.CliName)
 	}
 
+	if ver == version.NightlyVersion {
+		return fmt.Sprintf("%s version %s-%s (commit: %s)\n", config.CliName, ver, buildDate, commit)
+	}
+
 	ver = strings.TrimPrefix(ver, "v")
 
 	return fmt.Sprintf("%s version %s (build date: %s commit: %s)\n%s\n", config.CliName, ver, buildDate, commit, changelogURL(ver))

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -14,7 +14,10 @@
 
 package version
 
-const DevVersion = "dev"
+const (
+	DevVersion     = "dev"
+	NightlyVersion = "nightly"
+)
 
 var (
 	Version = DevVersion


### PR DESCRIPTION
## What is the purpose of the change

<!-- (For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).) -->

## Brief change log

<!-- *(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache* -->
