### PR TITLE
disable release when version is nightly 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "v*"
-      - "nightly-*"
 
 jobs:
   goreleaser_and_TiUP:
@@ -72,13 +71,10 @@ jobs:
             'linux arm64'
           )
           
-          # check if the tag name is nightly
-          if [[ "$REL_VER" == *nightly-* ]]; then
-            export VER="${REL_VER}"
-          else
+         
           # skip the first letter v in the tag name
             export VER="${REL_VER:1}"
-          fi
+
             for item in "${matrix[@]}" ; do
               os_arch=($item)
               os=(${os_arch[0]})
@@ -97,7 +93,7 @@ jobs:
             done
 
   create-pr:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: contains(github.ref, 'nightly') == false
     runs-on: ubuntu-latest
     needs: ["goreleaser_and_TiUP"]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: v1.12.3
-          args: release --release-notes=.CHANGELOG.md
+          args: release ${{ contains(github.ref, 'nightly') && '--skip==publish' || '--release-notes=.CHANGELOG.md' }}
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           GORELEASER_CURRENT_TAG: ${{steps.changelog.outputs.TAG_NAME}}

--- a/internal/cli/version/version.go
+++ b/internal/cli/version/version.go
@@ -41,7 +41,6 @@ func VersionCmd(h *internal.Helper) *cobra.Command {
 
 // Format formats a version string with the given information.
 func Format(ver, commit, buildDate string) string {
-	fmt.Println("ver:", ver)
 	if ver == version.DevVersion && buildDate == "" && commit == "" {
 		return fmt.Sprintf("%s version (built from source)", config.CliName)
 	}


### PR DESCRIPTION
## What is the purpose of the change

<!-- (For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).) -->

## Brief change log

<!-- *(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache* -->
