### PR TITLE
update nighly version format

### DIFF
--- a/internal/cli/version/version.go
+++ b/internal/cli/version/version.go
@@ -46,7 +46,7 @@ func Format(ver, commit, buildDate string) string {
 	}
 
 	if strings.Contains(ver, version.NightlyVersion) {
-		return fmt.Sprintf("%s version %s-%s (commit: %s)\n", config.CliName, ver, buildDate, commit)
+		return fmt.Sprintf("%s version %s (build date: %s commit: %s)\n", config.CliName, ver, buildDate, commit)
 	}
 
 	ver = strings.TrimPrefix(ver, "v")


### PR DESCRIPTION
## What is the purpose of the change

<!-- (For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).) -->

## Brief change log

<!-- *(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache* -->
