### PR TITLE
Polish error hint

### DIFF
--- a/internal/config/store/keyring.go
+++ b/internal/config/store/keyring.go
@@ -23,7 +23,7 @@ import (
 
 const namespace = "ticloud_access_token"
 
-var ErrNotSupported = errors.New("keyring is not supported, you can add `--insecure-storage true` to save token to config file instead.\n" +
+var ErrNotSupported = errors.New("keyring is not supported, you can add `--insecure-storage` to save token to config file instead.\n" +
 	"Or see https://github.com/zalando/go-keyring#dependencies for more details of keyring dependencies.")
 
 func Get(profile string) (string, error) {


### PR DESCRIPTION
## What is the purpose of the change

<!-- (For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).) -->

## Brief change log

<!-- *(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache* -->
