### PR TITLE
add whoami

### DIFF
--- a/docs/generate_doc/ticloud_auth.md
+++ b/docs/generate_doc/ticloud_auth.md
@@ -21,4 +21,5 @@ Login and logout via TiDB Cloud API
 * [ticloud](ticloud.md)	 - CLI tool to manage TiDB Cloud
 * [ticloud auth login](ticloud_auth_login.md)	 - Authenticate with TiDB Cloud
 * [ticloud auth logout](ticloud_auth_logout.md)	 - Log out of TiDB Cloud
+* [ticloud auth whoami](ticloud_auth_whoami.md)	 - Display information about the current user
 

--- a/docs/generate_doc/ticloud_auth_whoami.md
+++ b/docs/generate_doc/ticloud_auth_whoami.md
@@ -9,8 +9,8 @@ ticloud auth whoami [flags]
 ### Examples
 
 ```
-  To display information about the current user::
-		  $ ticloud auth whoami
+  To display information about the current user:
+  $ ticloud auth whoami
 ```
 
 ### Options

--- a/docs/generate_doc/ticloud_auth_whoami.md
+++ b/docs/generate_doc/ticloud_auth_whoami.md
@@ -16,8 +16,7 @@ ticloud auth whoami [flags]
 ### Options
 
 ```
-  -h, --help            help for whoami
-  -o, --output string   Output format, one of ["human" "json"]. For the complete result, please use json format. (default "human")
+  -h, --help   help for whoami
 ```
 
 ### Options inherited from parent commands

--- a/docs/generate_doc/ticloud_auth_whoami.md
+++ b/docs/generate_doc/ticloud_auth_whoami.md
@@ -1,0 +1,34 @@
+## ticloud auth whoami
+
+Display information about the current user
+
+```
+ticloud auth whoami [flags]
+```
+
+### Examples
+
+```
+  To display information about the current user::
+		  $ ticloud auth whoami
+```
+
+### Options
+
+```
+  -h, --help            help for whoami
+  -o, --output string   Output format, one of ["human" "json"]. For the complete result, please use json format. (default "human")
+```
+
+### Options inherited from parent commands
+
+```
+  -D, --debug            Enable debug mode
+      --no-color         Disable color output
+  -P, --profile string   Profile to use from your configuration file
+```
+
+### SEE ALSO
+
+* [ticloud auth](ticloud_auth.md)	 - Login and logout via TiDB Cloud API
+

--- a/docs/generate_doc/ticloud_serverless_create.md
+++ b/docs/generate_doc/ticloud_serverless_create.md
@@ -22,6 +22,7 @@ ticloud serverless create [flags]
 ### Options
 
 ```
+      --disable-public-endpoint        Whether the public endpoint is disabled. (optional)
   -n, --display-name string            Display name of the cluster to de created.
       --encryption                     Whether Enhanced Encryption at Rest is enabled. (optional)
   -h, --help                           help for create

--- a/docs/generate_doc/ticloud_serverless_update.md
+++ b/docs/generate_doc/ticloud_serverless_update.md
@@ -22,15 +22,16 @@ ticloud serverless update [flags]
 ### Options
 
 ```
-      --annotations string    The annotations of the cluster to be added or updated.
-                              Interactive example: {"annotation1":"value1","annotation2":"value2"}.
-                              NonInteractive example: "{\"annotation1\":\"value1\",\"annotation2\":\"value2\"}".
-  -c, --cluster-id string     The ID of the cluster to be updated.
-  -n, --display-name string   The new displayName of the cluster to be updated.
-  -h, --help                  help for update
-      --labels string         The labels of the cluster to be added or updated.
-                              Interactive example: {"label1":"value1","label2":"value2"}.
-                              NonInteractive example: "{\"label1\":\"value1\",\"label2\":\"value2\"}".
+      --annotations string        The annotations of the cluster to be added or updated.
+                                  Interactive example: {"annotation1":"value1","annotation2":"value2"}.
+                                  NonInteractive example: "{\"annotation1\":\"value1\",\"annotation2\":\"value2\"}".
+  -c, --cluster-id string         The ID of the cluster to be updated.
+      --disable-public-endpoint   Disable the public endpoint of the cluster.
+  -n, --display-name string       The new displayName of the cluster to be updated.
+  -h, --help                      help for update
+      --labels string             The labels of the cluster to be added or updated.
+                                  Interactive example: {"label1":"value1","label2":"value2"}.
+                                  NonInteractive example: "{\"label1\":\"value1\",\"label2\":\"value2\"}".
 ```
 
 ### Options inherited from parent commands

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -24,9 +24,10 @@ const (
 	tokenTypeHint = "access_token"
 	grantType     = "urn:ietf:params:oauth:grant-type:device_code"
 
-	authPath   = "/v1/device_authorization"
-	accessPath = "/v1/token"
-	revokePath = "/v1/revoke"
+	authPath     = "/v1/device_authorization"
+	accessPath   = "/v1/token"
+	revokePath   = "/v1/revoke"
+	userInfoPath = "/v1/userinfo"
 
 	errSlowDown = "slow_down"
 	errPending  = "authorization_pending"
@@ -40,5 +41,6 @@ func AuthCmd(h *internal.Helper) *cobra.Command {
 
 	authCmd.AddCommand(LoginCmd(h))
 	authCmd.AddCommand(LogoutCmd(h))
+	authCmd.AddCommand(WhoamiCmd(h))
 	return authCmd
 }

--- a/internal/cli/auth/whoami.go
+++ b/internal/cli/auth/whoami.go
@@ -1,0 +1,127 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"tidbcloud-cli/internal"
+	"tidbcloud-cli/internal/config"
+	"tidbcloud-cli/internal/config/store"
+	"tidbcloud-cli/internal/flag"
+	"tidbcloud-cli/internal/output"
+
+	"github.com/fatih/color"
+	"github.com/go-resty/resty/v2"
+	"github.com/juju/errors"
+	"github.com/spf13/cobra"
+	_ "github.com/xo/usql/drivers/mysql"
+	"github.com/zalando/go-keyring"
+)
+
+type WhoamiOpts struct {
+	client *resty.Client
+}
+
+func WhoamiCmd(h *internal.Helper) *cobra.Command {
+	opts := WhoamiOpts{
+		client: resty.New(),
+	}
+	var whoamiCmd = &cobra.Command{
+		Use:   "whoami",
+		Short: "Display information about the current user",
+		Args:  cobra.NoArgs,
+		Example: fmt.Sprintf(`  To display information about the current user::
+		  $ %[1]s auth whoami`, config.CliName),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			debug, err := cmd.Flags().GetBool(flag.Debug)
+			if err != nil {
+				return err
+			}
+			opts.client.SetDebug(debug)
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			token, err := config.GetAccessToken()
+			if err != nil {
+				if errors.Is(err, keyring.ErrNotFound) || errors.Is(err, store.ErrNotSupported) {
+					fmt.Fprintln(h.IOStreams.Out, color.YellowString("You are not logged in."))
+					return nil
+				}
+				return err
+			}
+
+			resp, err := opts.client.R().
+				SetContext(ctx).
+				SetHeader("Authorization", "Bearer "+token).
+				Get(fmt.Sprintf("%s%s", config.GetOAuthEndpoint(), userInfoPath))
+
+			if err != nil {
+				return err
+			}
+
+			if !resp.IsSuccess() {
+				return errors.Errorf("Failed to get user info, code: %s", resp.Status())
+			}
+
+			format, err := cmd.Flags().GetString(flag.Output)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			// for terminal which can prompt, humanFormat is the default format.
+			// for other terminals, json format is the default format.
+			if format == output.JsonFormat || !h.IOStreams.CanPrompt {
+				err := output.PrintJson(h.IOStreams.Out, resp.String())
+				if err != nil {
+					return errors.Trace(err)
+				}
+			} else if format == output.HumanFormat {
+				var userInfo UserInfo
+				err = json.Unmarshal(resp.Body(), &userInfo)
+				if err != nil {
+					fmt.Printf("Error parsing JSON: %v\n", err)
+					return err
+    			}
+
+				columns := []output.Column{
+					"email",
+					"username",
+				}
+
+				var rows []output.Row
+				rows = append(rows, output.Row{
+					userInfo.Email,
+					userInfo.Username,
+				})
+				err = output.PrintHumanTable(h.IOStreams.Out, columns, rows)
+				if err != nil {
+					return errors.Trace(err)
+				}
+			}
+			return nil
+		},
+	}
+
+	whoamiCmd.Flags().StringP(flag.Output, flag.OutputShort, output.HumanFormat, flag.OutputHelp)
+	return whoamiCmd
+}
+
+type UserInfo struct {
+	Email    string `json:"email"`
+	Username string `json:"username"`
+}

--- a/internal/cli/auth/whoami.go
+++ b/internal/cli/auth/whoami.go
@@ -44,7 +44,7 @@ func WhoamiCmd(h *internal.Helper) *cobra.Command {
 		Short: "Display information about the current user",
 		Args:  cobra.NoArgs,
 		Example: fmt.Sprintf(`  To display information about the current user::
-		  $ %[1]s auth whoami`, config.CliName),
+  $ %[1]s auth whoami`, config.CliName),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			debug, err := cmd.Flags().GetBool(flag.Debug)
 			if err != nil {

--- a/internal/cli/auth/whoami.go
+++ b/internal/cli/auth/whoami.go
@@ -44,7 +44,7 @@ func WhoamiCmd(h *internal.Helper) *cobra.Command {
 		Use:   "whoami",
 		Short: "Display information about the current user",
 		Args:  cobra.NoArgs,
-		Example: fmt.Sprintf(`  To display information about the current user::
+		Example: fmt.Sprintf(`  To display information about the current user:
   $ %[1]s auth whoami`, config.CliName),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			debug, err := cmd.Flags().GetBool(flag.Debug)

--- a/internal/cli/auth/whoami.go
+++ b/internal/cli/auth/whoami.go
@@ -96,7 +96,7 @@ func WhoamiCmd(h *internal.Helper) *cobra.Command {
 				if err != nil {
 					fmt.Printf("Error parsing JSON: %v\n", err)
 					return err
-    			}
+				}
 
 				columns := []output.Column{
 					"email",

--- a/internal/cli/auth/whoami.go
+++ b/internal/cli/auth/whoami.go
@@ -22,6 +22,7 @@ import (
 	"tidbcloud-cli/internal/config"
 	"tidbcloud-cli/internal/config/store"
 	"tidbcloud-cli/internal/flag"
+	ver "tidbcloud-cli/internal/version"
 
 	"github.com/fatih/color"
 	"github.com/go-resty/resty/v2"
@@ -67,6 +68,7 @@ func WhoamiCmd(h *internal.Helper) *cobra.Command {
 			resp, err := opts.client.R().
 				SetContext(ctx).
 				SetHeader("Authorization", "Bearer "+token).
+				SetHeader("user-agent", fmt.Sprintf("%s/%s", config.CliName, ver.Version)).
 				Get(fmt.Sprintf("%s%s", config.GetOAuthEndpoint(), userInfoPath))
 
 			if err != nil {

--- a/internal/cli/auth/whoami.go
+++ b/internal/cli/auth/whoami.go
@@ -82,7 +82,6 @@ func WhoamiCmd(h *internal.Helper) *cobra.Command {
 			var userInfo UserInfo
 			err = json.Unmarshal(resp.Body(), &userInfo)
 			if err != nil {
-				fmt.Printf("Error parsing JSON: %v\n", err)
 				return err
 			}
 


### PR DESCRIPTION
## What is the purpose of the change
Close #212 
<!-- (For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).) -->

## Brief change log

<!-- *(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache* -->
