### PR TITLE
add org name in whoami

### DIFF
--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -28,6 +28,7 @@ const (
 	accessPath   = "/v1/token"
 	revokePath   = "/v1/revoke"
 	userInfoPath = "/v1/userinfo"
+	orgPath      = "/v1beta1/org"
 
 	errSlowDown = "slow_down"
 	errPending  = "authorization_pending"

--- a/internal/cli/auth/whoami.go
+++ b/internal/cli/auth/whoami.go
@@ -77,7 +77,7 @@ func WhoamiCmd(h *internal.Helper) *cobra.Command {
 			})
 
 			go getUserInfoAsync(ctx, opts.client, token, chUserInfo)
-			go getOrgInfoAync(ctx, opts.client, token, chOrgInfo)
+			go getOrgInfoAsync(ctx, opts.client, token, chOrgInfo)
 
 			var userInfo *UserInfo
 			var orgInfo *OrgInfo

--- a/internal/cli/auth/whoami.go
+++ b/internal/cli/auth/whoami.go
@@ -82,10 +82,8 @@ func WhoamiCmd(h *internal.Helper) *cobra.Command {
 				results <- getOrgInfo(ctx, opts.client, token)
 			}()
 
-			go func() {
-				wg.Wait()
-				close(results)
-			}()
+			wg.Wait()
+			close(results)
 
 			var userInfo *UserInfo
 			var orgInfo *OrgInfo


### PR DESCRIPTION
## What is the purpose of the change

<!-- (For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).) -->

## Brief change log

<!-- *(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache* -->
